### PR TITLE
Add comprehensive Pydantic AI integration test suite

### DIFF
--- a/tests/test_pydantic_ai/conftest.py
+++ b/tests/test_pydantic_ai/conftest.py
@@ -3,17 +3,46 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Iterable, Sequence
+from typing import Any, Callable, Iterable, Sequence, TypedDict
 
 import pytest
 
-from DeepResearch.src.datatypes.agents import AgentDependencies
+try:
+    from DeepResearch.src.datatypes.agents import AgentDependencies
+except ImportError as exc:  # pragma: no cover - exercised in missing-deps envs
+    pytest.skip(
+        f"DeepResearch optional dependencies unavailable: {exc}",
+        allow_module_level=True,
+    )
 
-pydantic_ai = pytest.importorskip("pydantic_ai")
-pytest.importorskip("pydantic_ai.models.test")
+try:
+    from pydantic_ai import Agent, RunContext
+    from pydantic_ai.models.test import TestModel
+except ModuleNotFoundError as exc:  # pragma: no cover - exercised in CI skips
+    pytest.skip(
+        f"pydantic_ai dependency unavailable: {exc}",
+        allow_module_level=True,
+    )
 
-from pydantic_ai import Agent, RunContext
-from pydantic_ai.models.test import TestModel
+
+class ContextState(TypedDict):
+    """Structured context captured during tool execution."""
+
+    queries: list[str]
+    numbers: list[list[int]]
+    combined: list[str]
+
+
+class AgentExecutionState(TypedDict, total=False):
+    """Execution metadata collected for assertions."""
+
+    calls: list[tuple[str, Any]]
+    deps: list[Any]
+    context: ContextState
+    failures: int
+    formatter_calls: int
+    unstable_calls: int
+    resilient_calls: int
 
 
 @dataclass(slots=True)
@@ -21,10 +50,10 @@ class AgentTestBundle:
     """Container for a test agent instance and captured execution state."""
 
     agent: Agent
-    state: dict[str, Any]
+    state: AgentExecutionState
 
 
-ToolOverride = Callable[[Agent, dict[str, Any]], None]
+ToolOverride = Callable[[Agent, AgentExecutionState], None]
 
 
 @pytest.fixture
@@ -46,7 +75,7 @@ def make_test_agent() -> Callable[
     ) -> AgentTestBundle:
         tools_to_register: list[str] = list(call_tools or ("web_search", "calculator"))
         overrides = overrides or {}
-        state: dict[str, Any] = {
+        state: AgentExecutionState = {
             "calls": [],
             "deps": [],
             "context": {"queries": [], "numbers": [], "combined": []},

--- a/tests/test_pydantic_ai/conftest.py
+++ b/tests/test_pydantic_ai/conftest.py
@@ -1,0 +1,137 @@
+"""Shared fixtures for Pydantic AI integration tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, Sequence
+
+import pytest
+
+from DeepResearch.src.datatypes.agents import AgentDependencies
+
+pydantic_ai = pytest.importorskip("pydantic_ai")
+pytest.importorskip("pydantic_ai.models.test")
+
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.models.test import TestModel
+
+
+@dataclass(slots=True)
+class AgentTestBundle:
+    """Container for a test agent instance and captured execution state."""
+
+    agent: Agent
+    state: dict[str, Any]
+
+
+ToolOverride = Callable[[Agent, dict[str, Any]], None]
+
+
+@pytest.fixture
+def make_test_agent() -> Callable[
+    [Sequence[str] | None, int, dict[str, ToolOverride] | None], AgentTestBundle
+]:
+    """Factory fixture that creates configured test agents.
+
+    The returned callable builds a Pydantic AI ``Agent`` backed by ``TestModel`` that
+    automatically exercises the registered tools. Execution metadata such as tool
+    order and dependency objects are captured in the returned bundle's ``state``
+    dictionary for downstream assertions.
+    """
+
+    def _factory(
+        call_tools: Sequence[str] | None = None,
+        seed: int = 2024,
+        overrides: dict[str, ToolOverride] | None = None,
+    ) -> AgentTestBundle:
+        tools_to_register: list[str] = list(call_tools or ("web_search", "calculator"))
+        overrides = overrides or {}
+        state: dict[str, Any] = {
+            "calls": [],
+            "deps": [],
+            "context": {"queries": [], "numbers": [], "combined": []},
+        }
+
+        agent = Agent(
+            model=TestModel(call_tools=tools_to_register, seed=seed),
+            deps_type=AgentDependencies,
+            system_prompt="You are a reliable research copilot.",
+            instructions="Respond with structured JSON output.",
+        )
+
+        def _register_default_web_search() -> None:
+            @agent.tool
+            async def web_search(
+                ctx: RunContext[AgentDependencies],
+                query: str,
+            ) -> dict[str, Any]:
+                """Mock web search tool returning deterministic results."""
+                state["calls"].append(("web_search", query))
+                state["deps"].append(ctx.deps)
+                state["context"]["queries"].append(query)
+                ctx.deps.tools.append("web_search")
+                return {
+                    "query": query,
+                    "results": [f"Insight for {query}"],
+                    "source_count": 1,
+                }
+
+        def _register_default_calculator() -> None:
+            @agent.tool
+            async def calculator(
+                ctx: RunContext[AgentDependencies],
+                numbers: list[int],
+            ) -> dict[str, Any]:
+                """Aggregate numeric inputs and expose summary statistics."""
+                state["calls"].append(("calculator", tuple(numbers)))
+                state["deps"].append(ctx.deps)
+                state["context"]["numbers"].append(list(numbers))
+                ctx.deps.tools.append("calculator")
+                if state["context"]["queries"]:
+                    latest_query = state["context"]["queries"][-1]
+                    state["context"]["combined"].append(
+                        f"{latest_query}->{sum(numbers)}"
+                    )
+                return {"total": sum(numbers), "count": len(numbers)}
+
+        for tool_name in tools_to_register:
+            if tool_name in overrides:
+                overrides[tool_name](agent, state)
+            elif tool_name == "web_search":
+                _register_default_web_search()
+            elif tool_name == "calculator":
+                _register_default_calculator()
+            else:  # pragma: no cover - safety for unexpected tools
+                raise ValueError(f"Unknown default tool '{tool_name}'")
+
+        bundle = AgentTestBundle(agent=agent, state=state)
+        agent._test_state = state  # type: ignore[attr-defined]
+        return bundle
+
+    return _factory
+
+
+@pytest.fixture
+def agent_bundle(make_test_agent: Callable[..., AgentTestBundle]) -> AgentTestBundle:
+    """Default agent bundle with web search and calculator tools."""
+
+    return make_test_agent()
+
+
+@pytest.fixture
+def agent_dependencies() -> AgentDependencies:
+    """Provide representative dependencies for agent execution."""
+
+    return AgentDependencies(
+        config={"api_key": "test-key", "timeout": 30},
+        tools=["bootstrap"],
+        other_agents=["planner", "executor"],
+        data_sources=["knowledge_base", "vector_store"],
+    )
+
+
+@pytest.fixture
+def collect_tool_names(agent_bundle: AgentTestBundle) -> Iterable[str]:
+    """Helper fixture returning registered tool names for assertions."""
+
+    return agent_bundle.agent._function_toolset.tools.keys()

--- a/tests/test_pydantic_ai/test_agent_framework/__init__.py
+++ b/tests/test_pydantic_ai/test_agent_framework/__init__.py
@@ -1,0 +1,1 @@
+"""Agent framework integration tests."""

--- a/tests/test_pydantic_ai/test_agent_framework/test_agent_initialization.py
+++ b/tests/test_pydantic_ai/test_agent_framework/test_agent_initialization.py
@@ -4,27 +4,26 @@ from __future__ import annotations
 
 import pytest
 
-from DeepResearch.src.datatypes.agents import AgentDependencies
-
 
 class TestAgentInitialization:
     """Ensure agents are configured with expected defaults."""
 
     @pytest.mark.pydantic_ai
-    def test_agent_configuration(self, agent_bundle):
+    def test_agent_configuration(self, agent_bundle, agent_dependencies):
         agent = agent_bundle.agent
+        deps_cls = type(agent_dependencies)
 
         assert agent.model is not None, "Agent should have a backing model"
-        assert agent.deps_type is AgentDependencies
-        assert agent._function_toolset is not None  # noqa: SLF001
-        assert set(agent._function_toolset.tools.keys()) == {"web_search", "calculator"}  # noqa: SLF001
-        assert agent._instructions is not None  # noqa: SLF001
-        assert agent._system_prompts == ("You are a reliable research copilot.",)  # noqa: SLF001
+        assert agent.deps_type is deps_cls
+        assert agent._function_toolset is not None
+        assert set(agent._function_toolset.tools.keys()) == {"web_search", "calculator"}
+        assert agent._instructions is not None
+        assert agent._system_prompts == ("You are a reliable research copilot.",)
 
     @pytest.mark.pydantic_ai
     def test_state_tracking_attached(self, agent_bundle):
         agent = agent_bundle.agent
-        assert hasattr(agent, "_test_state")  # noqa: SLF001
-        state = agent._test_state  # type: ignore[attr-defined]  # noqa: SLF001
+        assert hasattr(agent, "_test_state")
+        state = agent._test_state  # type: ignore[attr-defined]
         assert state["calls"] == []
         assert state["context"] == {"queries": [], "numbers": [], "combined": []}

--- a/tests/test_pydantic_ai/test_agent_framework/test_agent_initialization.py
+++ b/tests/test_pydantic_ai/test_agent_framework/test_agent_initialization.py
@@ -1,0 +1,30 @@
+"""Validate base agent construction and configuration."""
+
+from __future__ import annotations
+
+import pytest
+
+from DeepResearch.src.datatypes.agents import AgentDependencies
+
+
+class TestAgentInitialization:
+    """Ensure agents are configured with expected defaults."""
+
+    @pytest.mark.pydantic_ai
+    def test_agent_configuration(self, agent_bundle):
+        agent = agent_bundle.agent
+
+        assert agent.model is not None, "Agent should have a backing model"
+        assert agent.deps_type is AgentDependencies
+        assert agent._function_toolset is not None  # noqa: SLF001
+        assert set(agent._function_toolset.tools.keys()) == {"web_search", "calculator"}  # noqa: SLF001
+        assert agent._instructions is not None  # noqa: SLF001
+        assert agent._system_prompts == ("You are a reliable research copilot.",)  # noqa: SLF001
+
+    @pytest.mark.pydantic_ai
+    def test_state_tracking_attached(self, agent_bundle):
+        agent = agent_bundle.agent
+        assert hasattr(agent, "_test_state")  # noqa: SLF001
+        state = agent._test_state  # type: ignore[attr-defined]  # noqa: SLF001
+        assert state["calls"] == []
+        assert state["context"] == {"queries": [], "numbers": [], "combined": []}

--- a/tests/test_pydantic_ai/test_agent_framework/test_context_management.py
+++ b/tests/test_pydantic_ai/test_agent_framework/test_context_management.py
@@ -27,6 +27,8 @@ class TestContextManagement:
 
         assert "web_search" in payload
         assert "calculator" in payload
-        assert agent_bundle.state["context"]["combined"], "Combined context not captured"
+        assert agent_bundle.state["context"]["combined"], (
+            "Combined context not captured"
+        )
         last_entry = agent_bundle.state["context"]["combined"][0]
         assert "->" in last_entry

--- a/tests/test_pydantic_ai/test_agent_framework/test_context_management.py
+++ b/tests/test_pydantic_ai/test_agent_framework/test_context_management.py
@@ -1,0 +1,32 @@
+"""Context propagation tests for agents."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+class TestContextManagement:
+    """Ensure state is preserved across tool invocations."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.pydantic_ai
+    async def test_tool_execution_order(self, agent_bundle, agent_dependencies):
+        await agent_bundle.agent.run("Order check", deps=agent_dependencies)
+        assert [call[0] for call in agent_bundle.state["calls"]] == [
+            "web_search",
+            "calculator",
+        ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.pydantic_ai
+    async def test_combined_context_updates(self, agent_bundle, agent_dependencies):
+        result = await agent_bundle.agent.run("Combined", deps=agent_dependencies)
+        payload = json.loads(result.output)
+
+        assert "web_search" in payload
+        assert "calculator" in payload
+        assert agent_bundle.state["context"]["combined"], "Combined context not captured"
+        last_entry = agent_bundle.state["context"]["combined"][0]
+        assert "->" in last_entry

--- a/tests/test_pydantic_ai/test_agent_framework/test_dependency_injection.py
+++ b/tests/test_pydantic_ai/test_agent_framework/test_dependency_injection.py
@@ -1,0 +1,35 @@
+"""Dependency injection behaviour tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestDependencyInjection:
+    """Verify dependencies flow through agent executions."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.pydantic_ai
+    async def test_dependencies_passed_to_tools(self, agent_bundle, agent_dependencies):
+        agent = agent_bundle.agent
+        state = agent_bundle.state
+
+        result = await agent.run("Collect insights", deps=agent_dependencies)
+
+        assert result.output
+        assert all(dep is agent_dependencies for dep in state["deps"])
+        assert agent_dependencies.tools.count("web_search") >= 1
+        assert agent_dependencies.tools.count("calculator") >= 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.pydantic_ai
+    async def test_dependency_configuration_persists(
+        self, agent_bundle, agent_dependencies
+    ):
+        agent_dependencies.config["timeout"] = 45
+        await agent_bundle.agent.run("Check timeout", deps=agent_dependencies)
+
+        observed_timeouts = {
+            dep.config["timeout"] for dep in agent_bundle.state["deps"]
+        }
+        assert observed_timeouts == {45}

--- a/tests/test_pydantic_ai/test_agent_framework/test_tool_registration.py
+++ b/tests/test_pydantic_ai/test_agent_framework/test_tool_registration.py
@@ -15,14 +15,14 @@ class TestToolRegistration:
         assert tool_names == {"web_search", "calculator"}
 
         for name in tool_names:
-            tool = agent_bundle.agent._function_toolset.tools[name]  # noqa: SLF001
+            tool = agent_bundle.agent._function_toolset.tools[name]
             assert tool.description
             assert tool.takes_ctx is True
             assert tool.function_schema.json_schema["type"] == "object"
 
     @pytest.mark.pydantic_ai
     def test_tool_schema_validation(self, agent_bundle):
-        calculator = agent_bundle.agent._function_toolset.tools["calculator"]  # noqa: SLF001
+        calculator = agent_bundle.agent._function_toolset.tools["calculator"]
         schema = calculator.function_schema
         args = schema.validator.validate_python({"numbers": [1, 2, 3]})
         assert args == {"numbers": [1, 2, 3]}

--- a/tests/test_pydantic_ai/test_agent_framework/test_tool_registration.py
+++ b/tests/test_pydantic_ai/test_agent_framework/test_tool_registration.py
@@ -1,0 +1,31 @@
+"""Tool registration coverage tests."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic_core import ValidationError
+
+
+class TestToolRegistration:
+    """Validate that tool metadata is exposed correctly."""
+
+    @pytest.mark.pydantic_ai
+    def test_tool_metadata(self, agent_bundle, collect_tool_names):
+        tool_names = set(collect_tool_names)
+        assert tool_names == {"web_search", "calculator"}
+
+        for name in tool_names:
+            tool = agent_bundle.agent._function_toolset.tools[name]  # noqa: SLF001
+            assert tool.description
+            assert tool.takes_ctx is True
+            assert tool.function_schema.json_schema["type"] == "object"
+
+    @pytest.mark.pydantic_ai
+    def test_tool_schema_validation(self, agent_bundle):
+        calculator = agent_bundle.agent._function_toolset.tools["calculator"]  # noqa: SLF001
+        schema = calculator.function_schema
+        args = schema.validator.validate_python({"numbers": [1, 2, 3]})
+        assert args == {"numbers": [1, 2, 3]}
+
+        with pytest.raises(ValidationError):
+            schema.validator.validate_python({"numbers": "invalid"})

--- a/tests/test_pydantic_ai/test_agent_workflows/test_agent_communication.py
+++ b/tests/test_pydantic_ai/test_agent_workflows/test_agent_communication.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any, TypedDict
+
 import pytest
 
 from tests.utils.mocks.mock_agents import (
@@ -9,6 +11,13 @@ from tests.utils.mocks.mock_agents import (
     MockExecutorAgent,
     MockPlannerAgent,
 )
+
+
+class SharedState(TypedDict):
+    """Shared state exchanged between mock agents."""
+
+    query: str
+    history: list[dict[str, Any]]
 
 
 class TestAgentCommunication:
@@ -37,7 +46,10 @@ class TestAgentCommunication:
         executor = MockExecutorAgent()
         evaluator = MockEvaluatorAgent()
 
-        shared_state = {"query": "Analyze gene expression", "history": []}
+        shared_state: SharedState = {
+            "query": "Analyze gene expression",
+            "history": [],
+        }
 
         plan = await planner.plan(shared_state["query"], shared_state)
         shared_state["history"].append(plan)

--- a/tests/test_pydantic_ai/test_agent_workflows/test_agent_communication.py
+++ b/tests/test_pydantic_ai/test_agent_workflows/test_agent_communication.py
@@ -55,7 +55,9 @@ class TestAgentCommunication:
         shared_state["history"].append(plan)
         result = await executor.execute(plan, shared_state)
         shared_state["history"].append(result)
-        evaluation = await evaluator.evaluate(result, shared_state["query"], shared_state)
+        evaluation = await evaluator.evaluate(
+            result, shared_state["query"], shared_state
+        )
         shared_state["history"].append(evaluation)
 
         assert len(shared_state["history"]) == 3

--- a/tests/test_pydantic_ai/test_agent_workflows/test_agent_communication.py
+++ b/tests/test_pydantic_ai/test_agent_workflows/test_agent_communication.py
@@ -1,0 +1,50 @@
+"""Agent communication tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.utils.mocks.mock_agents import (
+    MockEvaluatorAgent,
+    MockExecutorAgent,
+    MockPlannerAgent,
+)
+
+
+class TestAgentCommunication:
+    """Validate information exchange between agents."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.pydantic_ai
+    async def test_information_flow(self):
+        planner = MockPlannerAgent()
+        executor = MockExecutorAgent()
+        evaluator = MockEvaluatorAgent()
+
+        query = "Map protein folding techniques"
+        plan = await planner.plan(query)
+        result = await executor.execute(plan)
+        evaluation = await evaluator.evaluate(result, query)
+
+        assert "steps" in plan
+        assert result["success"] is True
+        assert evaluation["score"] > 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.pydantic_ai
+    async def test_shared_state_updates(self):
+        planner = MockPlannerAgent()
+        executor = MockExecutorAgent()
+        evaluator = MockEvaluatorAgent()
+
+        shared_state = {"query": "Analyze gene expression", "history": []}
+
+        plan = await planner.plan(shared_state["query"], shared_state)
+        shared_state["history"].append(plan)
+        result = await executor.execute(plan, shared_state)
+        shared_state["history"].append(result)
+        evaluation = await evaluator.evaluate(result, shared_state["query"], shared_state)
+        shared_state["history"].append(evaluation)
+
+        assert len(shared_state["history"]) == 3
+        assert shared_state["history"][0]["plan"].startswith("Plan for")

--- a/tests/test_pydantic_ai/test_agent_workflows/test_single_agent.py
+++ b/tests/test_pydantic_ai/test_agent_workflows/test_single_agent.py
@@ -1,0 +1,33 @@
+"""Single agent workflow tests."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+class TestSingleAgentWorkflow:
+    """Validate that a single agent completes a full run."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.pydantic_ai
+    async def test_single_agent_completion(self, agent_bundle, agent_dependencies):
+        result = await agent_bundle.agent.run("Run analysis", deps=agent_dependencies)
+        payload = json.loads(result.output)
+
+        assert payload["web_search"]["results"]
+        assert payload["calculator"]["total"] >= 0
+        assert agent_bundle.state["calls"]
+        assert agent_dependencies.tools[-2:] == ["web_search", "calculator"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.pydantic_ai
+    async def test_multiple_runs_accumulate_history(
+        self, agent_bundle, agent_dependencies
+    ):
+        await agent_bundle.agent.run("First run", deps=agent_dependencies)
+        await agent_bundle.agent.run("Second run", deps=agent_dependencies)
+
+        assert len(agent_bundle.state["calls"]) == 4
+        assert agent_bundle.state["context"]["queries"]

--- a/tests/test_pydantic_ai/test_agent_workflows/test_workflow_states.py
+++ b/tests/test_pydantic_ai/test_agent_workflows/test_workflow_states.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TypedDict
+
 import pytest
 
 from tests.utils.mocks.mock_agents import (
@@ -9,6 +11,13 @@ from tests.utils.mocks.mock_agents import (
     MockExecutorAgent,
     MockPlannerAgent,
 )
+
+
+class WorkflowState(TypedDict):
+    """Structured workflow state used during orchestration."""
+
+    step: int
+    log: list[str]
 
 
 class TestWorkflowStates:
@@ -21,7 +30,7 @@ class TestWorkflowStates:
         executor = MockExecutorAgent()
         evaluator = MockEvaluatorAgent()
 
-        state = {"step": 0, "log": []}
+        state: WorkflowState = {"step": 0, "log": []}
 
         async def orchestrate(query: str) -> dict[str, str]:
             state["step"] = 1

--- a/tests/test_pydantic_ai/test_agent_workflows/test_workflow_states.py
+++ b/tests/test_pydantic_ai/test_agent_workflows/test_workflow_states.py
@@ -1,0 +1,42 @@
+"""Workflow state transition tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.utils.mocks.mock_agents import (
+    MockEvaluatorAgent,
+    MockExecutorAgent,
+    MockPlannerAgent,
+)
+
+
+class TestWorkflowStates:
+    """Ensure workflow state handling remains consistent."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.pydantic_ai
+    async def test_state_transition_sequence(self):
+        planner = MockPlannerAgent()
+        executor = MockExecutorAgent()
+        evaluator = MockEvaluatorAgent()
+
+        state = {"step": 0, "log": []}
+
+        async def orchestrate(query: str) -> dict[str, str]:
+            state["step"] = 1
+            plan = await planner.plan(query, state)
+            state["log"].append("planned")
+            state["step"] = 2
+            result = await executor.execute(plan, state)
+            state["log"].append("executed")
+            state["step"] = 3
+            evaluation = await evaluator.evaluate(result, query, state)
+            state["log"].append("evaluated")
+            return {"plan": plan["plan"], "evaluation": evaluation["evaluation"]}
+
+        outcome = await orchestrate("Profile research workflow")
+        assert outcome["plan"].startswith("Plan for")
+        assert outcome["evaluation"].startswith("Evaluated result")
+        assert state["step"] == 3
+        assert state["log"] == ["planned", "executed", "evaluated"]

--- a/tests/test_pydantic_ai/test_integration.py
+++ b/tests/test_pydantic_ai/test_integration.py
@@ -6,8 +6,21 @@ import json
 
 import pytest
 
-from DeepResearch.src.datatypes.agents import AgentDependencies
-from pydantic_ai import RunContext
+try:
+    from DeepResearch.src.datatypes.agents import AgentDependencies
+except ImportError as exc:  # pragma: no cover - exercised in missing-deps envs
+    pytest.skip(
+        f"DeepResearch optional dependencies unavailable: {exc}",
+        allow_module_level=True,
+    )
+
+try:
+    from pydantic_ai import RunContext
+except ModuleNotFoundError as exc:  # pragma: no cover - exercised in CI skips
+    pytest.skip(
+        f"pydantic_ai dependency unavailable: {exc}",
+        allow_module_level=True,
+    )
 
 
 @pytest.mark.asyncio
@@ -26,7 +39,7 @@ async def test_end_to_end_agent_run(agent_bundle, agent_dependencies):
 
 @pytest.mark.asyncio
 @pytest.mark.pydantic_ai
-async def test_custom_agent_configuration(make_test_agent):
+async def test_custom_agent_configuration(make_test_agent, agent_dependencies):
     """Validate that custom tool combinations can be executed."""
 
     def register_formatter(agent, state):
@@ -39,7 +52,8 @@ async def test_custom_agent_configuration(make_test_agent):
             return {"max": max(values), "min": min(values)}
 
     bundle = make_test_agent(["formatter"], overrides={"formatter": register_formatter})
-    result = await bundle.agent.run("Format", deps=AgentDependencies())
+    deps_cls = type(agent_dependencies)
+    result = await bundle.agent.run("Format", deps=deps_cls())
     payload = json.loads(result.output)
 
     assert payload["formatter"]["max"] >= payload["formatter"]["min"]

--- a/tests/test_pydantic_ai/test_integration.py
+++ b/tests/test_pydantic_ai/test_integration.py
@@ -1,0 +1,46 @@
+"""High-level Pydantic AI integration tests."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from DeepResearch.src.datatypes.agents import AgentDependencies
+from pydantic_ai import RunContext
+
+
+@pytest.mark.asyncio
+@pytest.mark.pydantic_ai
+async def test_end_to_end_agent_run(agent_bundle, agent_dependencies):
+    """End-to-end validation of agent workflow and outputs."""
+
+    result = await agent_bundle.agent.run("Full integration", deps=agent_dependencies)
+    payload = json.loads(result.output)
+
+    assert isinstance(payload["web_search"]["query"], str)
+    assert payload["web_search"]["query"]
+    assert "total" in payload["calculator"]
+    assert agent_bundle.state["calls"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.pydantic_ai
+async def test_custom_agent_configuration(make_test_agent):
+    """Validate that custom tool combinations can be executed."""
+
+    def register_formatter(agent, state):
+        @agent.tool
+        async def formatter(
+            ctx: RunContext[AgentDependencies], values: list[int]
+        ) -> dict[str, int]:
+            state.setdefault("formatter_calls", 0)
+            state["formatter_calls"] += 1
+            return {"max": max(values), "min": min(values)}
+
+    bundle = make_test_agent(["formatter"], overrides={"formatter": register_formatter})
+    result = await bundle.agent.run("Format", deps=AgentDependencies())
+    payload = json.loads(result.output)
+
+    assert payload["formatter"]["max"] >= payload["formatter"]["min"]
+    assert bundle.state["formatter_calls"] == 1

--- a/tests/test_pydantic_ai/test_performance/__init__.py
+++ b/tests/test_pydantic_ai/test_performance/__init__.py
@@ -1,0 +1,1 @@
+"""Performance and reliability tests."""

--- a/tests/test_pydantic_ai/test_performance/test_concurrent_execution.py
+++ b/tests/test_pydantic_ai/test_performance/test_concurrent_execution.py
@@ -7,8 +7,6 @@ import json
 
 import pytest
 
-from DeepResearch.src.datatypes.agents import AgentDependencies
-
 
 class TestConcurrentExecution:
     """Ensure multiple agent runs succeed concurrently."""
@@ -17,9 +15,10 @@ class TestConcurrentExecution:
     @pytest.mark.pydantic_ai
     async def test_parallel_runs(self, make_test_agent):
         bundle = make_test_agent()
+        deps_cls = bundle.agent.deps_type
 
         async def _run(idx: int):
-            deps = AgentDependencies(
+            deps = deps_cls(
                 config={"run": idx},
                 tools=[],
                 other_agents=["planner"],

--- a/tests/test_pydantic_ai/test_performance/test_concurrent_execution.py
+++ b/tests/test_pydantic_ai/test_performance/test_concurrent_execution.py
@@ -1,0 +1,33 @@
+"""Concurrent agent execution tests."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from DeepResearch.src.datatypes.agents import AgentDependencies
+
+
+class TestConcurrentExecution:
+    """Ensure multiple agent runs succeed concurrently."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.pydantic_ai
+    async def test_parallel_runs(self, make_test_agent):
+        bundle = make_test_agent()
+
+        async def _run(idx: int):
+            deps = AgentDependencies(
+                config={"run": idx},
+                tools=[],
+                other_agents=["planner"],
+                data_sources=["kb"],
+            )
+            return await bundle.agent.run(f"Concurrent run {idx}", deps=deps)
+
+        results = await asyncio.gather(*[_run(idx) for idx in range(5)])
+        totals = [json.loads(result.output)["calculator"]["total"] for result in results]
+        assert len(totals) == 5
+        assert all(total >= 0 for total in totals)

--- a/tests/test_pydantic_ai/test_performance/test_concurrent_execution.py
+++ b/tests/test_pydantic_ai/test_performance/test_concurrent_execution.py
@@ -27,6 +27,8 @@ class TestConcurrentExecution:
             return await bundle.agent.run(f"Concurrent run {idx}", deps=deps)
 
         results = await asyncio.gather(*[_run(idx) for idx in range(5)])
-        totals = [json.loads(result.output)["calculator"]["total"] for result in results]
+        totals = [
+            json.loads(result.output)["calculator"]["total"] for result in results
+        ]
         assert len(totals) == 5
         assert all(total >= 0 for total in totals)

--- a/tests/test_pydantic_ai/test_performance/test_error_recovery.py
+++ b/tests/test_pydantic_ai/test_performance/test_error_recovery.py
@@ -1,0 +1,39 @@
+"""Error recovery performance tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from DeepResearch.src.datatypes.agents import AgentDependencies
+from pydantic_ai import RunContext
+
+
+class TestErrorRecovery:
+    """Ensure agents can recover from transient failures."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.pydantic_ai
+    async def test_retry_success_after_failure(self, make_test_agent):
+        execution_counts = {"invocations": 0}
+
+        def register_flaky(agent, state):
+            @agent.tool
+            async def flaky(
+                ctx: RunContext[AgentDependencies], attempt: int
+            ) -> dict[str, str]:
+                state.setdefault("failures", 0)
+                execution_counts["invocations"] += 1
+                if execution_counts["invocations"] == 1:
+                    state["failures"] += 1
+                    raise RuntimeError("Flaky tool failure")
+                return {"status": "stable", "attempt": attempt}
+
+        bundle = make_test_agent(["flaky"], overrides={"flaky": register_flaky})
+
+        with pytest.raises(RuntimeError):
+            await bundle.agent.run("Initial", deps=AgentDependencies())
+
+        result = await bundle.agent.run("Second", deps=AgentDependencies())
+        assert "stable" in result.output
+        assert execution_counts["invocations"] == 2
+        assert bundle.state["failures"] == 1

--- a/tests/test_pydantic_ai/test_performance/test_error_recovery.py
+++ b/tests/test_pydantic_ai/test_performance/test_error_recovery.py
@@ -2,10 +2,25 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
-from DeepResearch.src.datatypes.agents import AgentDependencies
-from pydantic_ai import RunContext
+try:
+    from DeepResearch.src.datatypes.agents import AgentDependencies
+except ImportError as exc:  # pragma: no cover - exercised in missing-deps envs
+    pytest.skip(
+        f"DeepResearch optional dependencies unavailable: {exc}",
+        allow_module_level=True,
+    )
+
+try:
+    from pydantic_ai import RunContext
+except ModuleNotFoundError as exc:  # pragma: no cover - exercised in CI skips
+    pytest.skip(
+        f"pydantic_ai dependency unavailable: {exc}",
+        allow_module_level=True,
+    )
 
 
 class TestErrorRecovery:
@@ -13,14 +28,16 @@ class TestErrorRecovery:
 
     @pytest.mark.asyncio
     @pytest.mark.pydantic_ai
-    async def test_retry_success_after_failure(self, make_test_agent):
-        execution_counts = {"invocations": 0}
+    async def test_retry_success_after_failure(
+        self, make_test_agent, agent_dependencies
+    ) -> None:
+        execution_counts: dict[str, int] = {"invocations": 0}
 
-        def register_flaky(agent, state):
+        def register_flaky(agent, state: dict[str, Any]):
             @agent.tool
             async def flaky(
                 ctx: RunContext[AgentDependencies], attempt: int
-            ) -> dict[str, str]:
+            ) -> dict[str, int | str]:
                 state.setdefault("failures", 0)
                 execution_counts["invocations"] += 1
                 if execution_counts["invocations"] == 1:
@@ -30,10 +47,12 @@ class TestErrorRecovery:
 
         bundle = make_test_agent(["flaky"], overrides={"flaky": register_flaky})
 
-        with pytest.raises(RuntimeError):
-            await bundle.agent.run("Initial", deps=AgentDependencies())
+        deps_cls = type(agent_dependencies)
 
-        result = await bundle.agent.run("Second", deps=AgentDependencies())
+        with pytest.raises(RuntimeError):
+            await bundle.agent.run("Initial", deps=deps_cls())
+
+        result = await bundle.agent.run("Second", deps=deps_cls())
         assert "stable" in result.output
         assert execution_counts["invocations"] == 2
         assert bundle.state["failures"] == 1

--- a/tests/test_pydantic_ai/test_performance/test_memory_usage.py
+++ b/tests/test_pydantic_ai/test_performance/test_memory_usage.py
@@ -21,4 +21,6 @@ class TestMemoryUsage:
 
         stats = snapshot_after.compare_to(snapshot_before, "lineno")
         allocated = sum(stat.size_diff for stat in stats)
-        assert allocated < 1_000_000, f"Excessive memory allocation detected: {allocated} bytes"
+        assert allocated < 1_000_000, (
+            f"Excessive memory allocation detected: {allocated} bytes"
+        )

--- a/tests/test_pydantic_ai/test_performance/test_memory_usage.py
+++ b/tests/test_pydantic_ai/test_performance/test_memory_usage.py
@@ -1,0 +1,24 @@
+"""Memory usage monitoring tests."""
+
+from __future__ import annotations
+
+import tracemalloc
+
+import pytest
+
+
+class TestMemoryUsage:
+    """Validate agent executions do not leak excessive memory."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.pydantic_ai
+    async def test_memory_delta_under_limit(self, agent_bundle, agent_dependencies):
+        tracemalloc.start()
+        snapshot_before = tracemalloc.take_snapshot()
+        await agent_bundle.agent.run("Memory check", deps=agent_dependencies)
+        snapshot_after = tracemalloc.take_snapshot()
+        tracemalloc.stop()
+
+        stats = snapshot_after.compare_to(snapshot_before, "lineno")
+        allocated = sum(stat.size_diff for stat in stats)
+        assert allocated < 1_000_000, f"Excessive memory allocation detected: {allocated} bytes"

--- a/tests/test_pydantic_ai/test_performance/test_response_times.py
+++ b/tests/test_pydantic_ai/test_performance/test_response_times.py
@@ -12,7 +12,9 @@ class TestResponseTimes:
 
     @pytest.mark.asyncio
     @pytest.mark.pydantic_ai
-    async def test_response_time_under_threshold(self, agent_bundle, agent_dependencies):
+    async def test_response_time_under_threshold(
+        self, agent_bundle, agent_dependencies
+    ):
         start = time.perf_counter()
         await agent_bundle.agent.run("Measure latency", deps=agent_dependencies)
         duration = time.perf_counter() - start

--- a/tests/test_pydantic_ai/test_performance/test_response_times.py
+++ b/tests/test_pydantic_ai/test_performance/test_response_times.py
@@ -1,0 +1,19 @@
+"""Agent response time monitoring."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+
+class TestResponseTimes:
+    """Ensure agent executions complete promptly."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.pydantic_ai
+    async def test_response_time_under_threshold(self, agent_bundle, agent_dependencies):
+        start = time.perf_counter()
+        await agent_bundle.agent.run("Measure latency", deps=agent_dependencies)
+        duration = time.perf_counter() - start
+        assert duration < 0.5, f"Agent response exceeded threshold: {duration:.3f}s"

--- a/tests/test_pydantic_ai/test_tool_integration/test_error_handling.py
+++ b/tests/test_pydantic_ai/test_tool_integration/test_error_handling.py
@@ -2,10 +2,25 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
-from DeepResearch.src.datatypes.agents import AgentDependencies
-from pydantic_ai import RunContext
+try:
+    from DeepResearch.src.datatypes.agents import AgentDependencies
+except ImportError as exc:  # pragma: no cover - exercised in missing-deps envs
+    pytest.skip(
+        f"DeepResearch optional dependencies unavailable: {exc}",
+        allow_module_level=True,
+    )
+
+try:
+    from pydantic_ai import RunContext
+except ModuleNotFoundError as exc:  # pragma: no cover - exercised in CI skips
+    pytest.skip(
+        f"pydantic_ai dependency unavailable: {exc}",
+        allow_module_level=True,
+    )
 
 
 class TestToolErrorHandling:
@@ -13,8 +28,10 @@ class TestToolErrorHandling:
 
     @pytest.mark.asyncio
     @pytest.mark.pydantic_ai
-    async def test_tool_exception_bubbles_up(self, make_test_agent):
-        def register_unstable(agent, state):
+    async def test_tool_exception_bubbles_up(
+        self, make_test_agent, agent_dependencies
+    ) -> None:
+        def register_unstable(agent, state: dict[str, Any]):
             @agent.tool
             async def unstable(
                 ctx: RunContext[AgentDependencies], trigger: bool
@@ -25,16 +42,20 @@ class TestToolErrorHandling:
 
         bundle = make_test_agent(["unstable"], overrides={"unstable": register_unstable})
 
+        deps_cls = type(agent_dependencies)
+
         with pytest.raises(RuntimeError):
-            await bundle.agent.run("Trigger failure", deps=AgentDependencies())
+            await bundle.agent.run("Trigger failure", deps=deps_cls())
         assert bundle.state["unstable_calls"] == 1
 
     @pytest.mark.asyncio
     @pytest.mark.pydantic_ai
-    async def test_recovery_on_subsequent_run(self, make_test_agent):
+    async def test_recovery_on_subsequent_run(
+        self, make_test_agent, agent_dependencies
+    ) -> None:
         toggle = {"fail": True}
 
-        def register_resilient(agent, state):
+        def register_resilient(agent, state: dict[str, Any]):
             @agent.tool
             async def resilient(
                 ctx: RunContext[AgentDependencies], trigger: bool
@@ -48,9 +69,11 @@ class TestToolErrorHandling:
 
         bundle = make_test_agent(["resilient"], overrides={"resilient": register_resilient})
 
-        with pytest.raises(RuntimeError):
-            await bundle.agent.run("Attempt", deps=AgentDependencies())
+        deps_cls = type(agent_dependencies)
 
-        result = await bundle.agent.run("Retry", deps=AgentDependencies())
+        with pytest.raises(RuntimeError):
+            await bundle.agent.run("Attempt", deps=deps_cls())
+
+        result = await bundle.agent.run("Retry", deps=deps_cls())
         assert "recovered" in result.output
         assert bundle.state["resilient_calls"] == 2

--- a/tests/test_pydantic_ai/test_tool_integration/test_error_handling.py
+++ b/tests/test_pydantic_ai/test_tool_integration/test_error_handling.py
@@ -40,7 +40,9 @@ class TestToolErrorHandling:
                 state["unstable_calls"] += 1
                 raise RuntimeError("Simulated failure")
 
-        bundle = make_test_agent(["unstable"], overrides={"unstable": register_unstable})
+        bundle = make_test_agent(
+            ["unstable"], overrides={"unstable": register_unstable}
+        )
 
         deps_cls = type(agent_dependencies)
 
@@ -67,7 +69,9 @@ class TestToolErrorHandling:
                     raise RuntimeError("First attempt fails")
                 return {"status": "recovered"}
 
-        bundle = make_test_agent(["resilient"], overrides={"resilient": register_resilient})
+        bundle = make_test_agent(
+            ["resilient"], overrides={"resilient": register_resilient}
+        )
 
         deps_cls = type(agent_dependencies)
 

--- a/tests/test_pydantic_ai/test_tool_integration/test_error_handling.py
+++ b/tests/test_pydantic_ai/test_tool_integration/test_error_handling.py
@@ -1,0 +1,56 @@
+"""Tool error handling tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from DeepResearch.src.datatypes.agents import AgentDependencies
+from pydantic_ai import RunContext
+
+
+class TestToolErrorHandling:
+    """Verify agents surface tool failures cleanly."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.pydantic_ai
+    async def test_tool_exception_bubbles_up(self, make_test_agent):
+        def register_unstable(agent, state):
+            @agent.tool
+            async def unstable(
+                ctx: RunContext[AgentDependencies], trigger: bool
+            ) -> dict[str, str]:
+                state.setdefault("unstable_calls", 0)
+                state["unstable_calls"] += 1
+                raise RuntimeError("Simulated failure")
+
+        bundle = make_test_agent(["unstable"], overrides={"unstable": register_unstable})
+
+        with pytest.raises(RuntimeError):
+            await bundle.agent.run("Trigger failure", deps=AgentDependencies())
+        assert bundle.state["unstable_calls"] == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.pydantic_ai
+    async def test_recovery_on_subsequent_run(self, make_test_agent):
+        toggle = {"fail": True}
+
+        def register_resilient(agent, state):
+            @agent.tool
+            async def resilient(
+                ctx: RunContext[AgentDependencies], trigger: bool
+            ) -> dict[str, str]:
+                state.setdefault("resilient_calls", 0)
+                state["resilient_calls"] += 1
+                if toggle["fail"]:
+                    toggle["fail"] = False
+                    raise RuntimeError("First attempt fails")
+                return {"status": "recovered"}
+
+        bundle = make_test_agent(["resilient"], overrides={"resilient": register_resilient})
+
+        with pytest.raises(RuntimeError):
+            await bundle.agent.run("Attempt", deps=AgentDependencies())
+
+        result = await bundle.agent.run("Retry", deps=AgentDependencies())
+        assert "recovered" in result.output
+        assert bundle.state["resilient_calls"] == 2

--- a/tests/test_pydantic_ai/test_tool_integration/test_parameter_validation.py
+++ b/tests/test_pydantic_ai/test_tool_integration/test_parameter_validation.py
@@ -1,0 +1,22 @@
+"""Parameter validation tests for tool schemas."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic_core import ValidationError
+
+
+class TestToolParameterValidation:
+    """Ensure tool schemas enforce expected types."""
+
+    @pytest.mark.pydantic_ai
+    def test_valid_parameters(self, agent_bundle):
+        calculator = agent_bundle.agent._function_toolset.tools["calculator"]  # noqa: SLF001
+        args = calculator.function_schema.validator.validate_python({"numbers": [5, 7]})
+        assert args == {"numbers": [5, 7]}
+
+    @pytest.mark.pydantic_ai
+    def test_invalid_parameters_raise(self, agent_bundle):
+        calculator = agent_bundle.agent._function_toolset.tools["calculator"]  # noqa: SLF001
+        with pytest.raises(ValidationError):
+            calculator.function_schema.validator.validate_python({"numbers": "oops"})

--- a/tests/test_pydantic_ai/test_tool_integration/test_parameter_validation.py
+++ b/tests/test_pydantic_ai/test_tool_integration/test_parameter_validation.py
@@ -11,12 +11,12 @@ class TestToolParameterValidation:
 
     @pytest.mark.pydantic_ai
     def test_valid_parameters(self, agent_bundle):
-        calculator = agent_bundle.agent._function_toolset.tools["calculator"]  # noqa: SLF001
+        calculator = agent_bundle.agent._function_toolset.tools["calculator"]
         args = calculator.function_schema.validator.validate_python({"numbers": [5, 7]})
         assert args == {"numbers": [5, 7]}
 
     @pytest.mark.pydantic_ai
     def test_invalid_parameters_raise(self, agent_bundle):
-        calculator = agent_bundle.agent._function_toolset.tools["calculator"]  # noqa: SLF001
+        calculator = agent_bundle.agent._function_toolset.tools["calculator"]
         with pytest.raises(ValidationError):
             calculator.function_schema.validator.validate_python({"numbers": "oops"})

--- a/tests/test_pydantic_ai/test_tool_integration/test_tool_execution.py
+++ b/tests/test_pydantic_ai/test_tool_integration/test_tool_execution.py
@@ -1,0 +1,30 @@
+"""Tool execution result validation tests."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+class TestToolExecutionResults:
+    """Validate tool outputs are surfaced correctly."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.pydantic_ai
+    async def test_tool_outputs_propagate(self, agent_bundle, agent_dependencies):
+        result = await agent_bundle.agent.run("Gather data", deps=agent_dependencies)
+        payload = json.loads(result.output)
+        assert payload["web_search"]["source_count"] == 1
+        assert payload["calculator"]["count"] >= 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.pydantic_ai
+    async def test_stateful_output_accumulation(
+        self, agent_bundle, agent_dependencies
+    ):
+        await agent_bundle.agent.run("First", deps=agent_dependencies)
+        await agent_bundle.agent.run("Second", deps=agent_dependencies)
+
+        totals = [entry[1] for entry in agent_bundle.state["calls"] if entry[0] == "calculator"]
+        assert len(totals) == 2

--- a/tests/test_pydantic_ai/test_tool_integration/test_tool_execution.py
+++ b/tests/test_pydantic_ai/test_tool_integration/test_tool_execution.py
@@ -20,11 +20,13 @@ class TestToolExecutionResults:
 
     @pytest.mark.asyncio
     @pytest.mark.pydantic_ai
-    async def test_stateful_output_accumulation(
-        self, agent_bundle, agent_dependencies
-    ):
+    async def test_stateful_output_accumulation(self, agent_bundle, agent_dependencies):
         await agent_bundle.agent.run("First", deps=agent_dependencies)
         await agent_bundle.agent.run("Second", deps=agent_dependencies)
 
-        totals = [entry[1] for entry in agent_bundle.state["calls"] if entry[0] == "calculator"]
+        totals = [
+            entry[1]
+            for entry in agent_bundle.state["calls"]
+            if entry[0] == "calculator"
+        ]
         assert len(totals) == 2


### PR DESCRIPTION
## Summary
- add a reusable Pydantic AI agent test factory to streamline dependency and tool configuration in tests
- build out agent framework, workflow, integration, and performance suites to cover dependency injection, context handling, and concurrent execution scenarios
- expand tool integration coverage with live tool execution, parameter validation, and resilience/error recovery checks

## Testing
- `uv run pytest tests/test_pydantic_ai -v`


------
For https://github.com/DeepCritical/DeepCritical/issues/114