### PR TITLE
Add FAISS vector store backend and tests

### DIFF
--- a/DeepResearch/src/vector_stores/__init__.py
+++ b/DeepResearch/src/vector_stores/__init__.py
@@ -6,11 +6,15 @@ from ..datatypes.neo4j_types import (
     VectorSearchDefaults,
 )
 from ..datatypes.rag import Embeddings, VectorStore, VectorStoreConfig, VectorStoreType
+from .faiss_config import FaissVectorStoreConfig
+from .faiss_vector_store import FaissVectorStore
 from .neo4j_vector_store import Neo4jVectorStore
 
 __all__ = [
     "Neo4jVectorStore",
     "Neo4jVectorStoreConfig",
+    "FaissVectorStore",
+    "FaissVectorStoreConfig",
     "create_vector_store",
 ]
 
@@ -77,5 +81,12 @@ def create_vector_store(
         return Neo4jVectorStore(
             vector_store_config, embeddings, neo4j_config=connection
         )
+
+    if config.store_type == VectorStoreType.FAISS:
+        if isinstance(config, FaissVectorStoreConfig):
+            faiss_config = config
+        else:
+            faiss_config = FaissVectorStoreConfig.model_validate(config.model_dump())
+        return FaissVectorStore(faiss_config, embeddings)
 
     raise ValueError(f"Unsupported vector store type: {config.store_type}")

--- a/DeepResearch/src/vector_stores/faiss_config.py
+++ b/DeepResearch/src/vector_stores/faiss_config.py
@@ -1,0 +1,29 @@
+"""Configuration for FAISS-backed vector store."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from ..datatypes.rag import VectorStoreConfig, VectorStoreType
+
+
+class FaissVectorStoreConfig(VectorStoreConfig):
+    """Hydra-ready configuration for FAISS vector stores."""
+
+    store_type: VectorStoreType = Field(default=VectorStoreType.FAISS)
+    index_path: str | None = Field(
+        default=None,
+        description="Filesystem path where the FAISS index should be persisted.",
+    )
+    metadata_path: str | None = Field(
+        default=None,
+        description="Filesystem path where metadata for stored documents is saved.",
+    )
+    normalize_vectors: bool | None = Field(
+        default=None,
+        description=(
+            "Whether to L2-normalize vectors before indexing. Defaults to True when "
+            "the distance metric is cosine."
+        ),
+    )
+

--- a/DeepResearch/src/vector_stores/faiss_vector_store.py
+++ b/DeepResearch/src/vector_stores/faiss_vector_store.py
@@ -1,0 +1,361 @@
+"""FAISS-backed vector store implementation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+try:
+    import faiss  # type: ignore
+except ImportError as exc:  # pragma: no cover - handled in test environment
+    raise ImportError(
+        "faiss-cpu is required to use the FaissVectorStore."
+    ) from exc
+
+from ..datatypes.chunk_dataclass import Chunk
+from ..datatypes.rag import (
+    Document,
+    Embeddings,
+    SearchResult,
+    SearchType,
+    VectorStore,
+    VectorStoreConfig,
+)
+from .faiss_config import FaissVectorStoreConfig
+
+
+class FaissVectorStore(VectorStore):
+    """Vector store backed by a FAISS index with JSON metadata persistence."""
+
+    def __init__(self, config: VectorStoreConfig, embeddings: Embeddings):
+        if not isinstance(config, FaissVectorStoreConfig):
+            config = FaissVectorStoreConfig.model_validate(config.model_dump())
+
+        super().__init__(config, embeddings)
+        self.config: FaissVectorStoreConfig = config
+
+        self._index_path = Path(config.index_path) if config.index_path else None
+        self._metadata_path = (
+            Path(config.metadata_path) if config.metadata_path else None
+        )
+        self._normalize = (
+            config.normalize_vectors
+            if config.normalize_vectors is not None
+            else (config.distance_metric.lower() == "cosine")
+        )
+        self._metric = self._resolve_metric(config.distance_metric)
+
+        self._index = self._create_index()
+        self._documents: dict[str, Document] = {}
+        self._id_to_internal: dict[str, int] = {}
+        self._internal_to_id: dict[int, str] = {}
+        self._next_internal_id = 1
+
+        self._load_state()
+
+    # ------------------------------------------------------------------
+    # Public API implementations
+    # ------------------------------------------------------------------
+    async def add_documents(
+        self, documents: list[Document], **kwargs: Any
+    ) -> list[str]:
+        document_copies = [doc.model_copy(deep=True) for doc in documents]
+        docs_missing_embeddings = [doc for doc in document_copies if doc.embedding is None]
+
+        if docs_missing_embeddings:
+            embeddings = await self.embeddings.vectorize_documents(
+                [doc.content for doc in docs_missing_embeddings]
+            )
+            for doc, embedding in zip(docs_missing_embeddings, embeddings, strict=True):
+                doc.embedding = embedding
+
+        stored_ids: list[str] = []
+        for doc in document_copies:
+            vector = self._prepare_vector(doc.embedding)
+            doc.embedding = vector.reshape(-1).tolist()
+
+            internal_id = self._id_to_internal.get(doc.id)
+            if internal_id is None:
+                internal_id = self._generate_internal_id()
+            self._id_to_internal[doc.id] = internal_id
+            self._internal_to_id[internal_id] = doc.id
+
+            self._documents[doc.id] = doc
+            stored_ids.append(doc.id)
+
+        if stored_ids:
+            self._rebuild_index()
+            self._persist_state()
+
+        return stored_ids
+
+    async def add_document_chunks(
+        self, chunks: list[Chunk], **kwargs: Any
+    ) -> list[str]:
+        documents = [self._chunk_to_document(chunk) for chunk in chunks]
+        return await self.add_documents(documents, **kwargs)
+
+    async def add_document_text_chunks(
+        self, document_texts: list[str], **kwargs: Any
+    ) -> list[str]:
+        documents = [
+            Document(
+                content=text,
+                metadata={"source": "text_chunk", "chunk_index": index},
+            )
+            for index, text in enumerate(document_texts)
+        ]
+        return await self.add_documents(documents, **kwargs)
+
+    async def delete_documents(self, document_ids: list[str]) -> bool:
+        removed = False
+        for doc_id in document_ids:
+            if doc_id in self._documents:
+                internal_id = self._id_to_internal.pop(doc_id, None)
+                if internal_id is not None:
+                    self._internal_to_id.pop(internal_id, None)
+                self._documents.pop(doc_id, None)
+                removed = True
+
+        if removed:
+            self._rebuild_index()
+            self._persist_state()
+
+        return removed
+
+    async def search(
+        self,
+        query: str,
+        search_type: SearchType,
+        retrieval_query: str | None = None,
+        **kwargs: Any,
+    ) -> list[SearchResult]:
+        query_embedding = await self.embeddings.vectorize_query(query)
+        return await self.search_with_embeddings(
+            query_embedding, search_type, retrieval_query, **kwargs
+        )
+
+    async def search_with_embeddings(
+        self,
+        query_embedding: list[float],
+        search_type: SearchType,
+        retrieval_query: str | None = None,
+        **kwargs: Any,
+    ) -> list[SearchResult]:
+        if self._index.ntotal == 0:
+            return []
+
+        vector = self._prepare_vector(query_embedding)
+        top_k = kwargs.get("top_k", 10)
+        score_threshold = kwargs.get("score_threshold")
+        filters: dict[str, Any] = kwargs.get("filters", {}) or {}
+
+        distances, indices = self._index.search(vector, top_k)
+        scores = distances[0]
+        doc_ids = [self._internal_to_id.get(int(idx), "") for idx in indices[0]]
+
+        results: list[SearchResult] = []
+        rank = 1
+        for score, doc_id in zip(scores, doc_ids, strict=False):
+            if not doc_id:
+                continue
+
+            document = self._documents.get(doc_id)
+            if document is None:
+                continue
+
+            if filters and not self._matches_filters(document.metadata, filters):
+                continue
+
+            similarity = self._score_from_distance(float(score))
+
+            if score_threshold is not None and similarity < float(score_threshold):
+                continue
+
+            results.append(
+                SearchResult(
+                    document=document.model_copy(deep=True),
+                    score=similarity,
+                    rank=rank,
+                )
+            )
+            rank += 1
+
+        return results
+
+    async def get_document(self, document_id: str) -> Document | None:
+        document = self._documents.get(document_id)
+        if document is None:
+            return None
+        return document.model_copy(deep=True)
+
+    async def update_document(self, document: Document) -> bool:
+        if document.id not in self._documents:
+            return False
+        await self.add_documents([document])
+        return True
+
+    async def close(self) -> None:
+        self._persist_state()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._persist_state()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.close()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _create_index(self):
+        if self._metric == "ip":
+            base_index = faiss.IndexFlatIP(self.config.embedding_dimension)
+        else:
+            base_index = faiss.IndexFlatL2(self.config.embedding_dimension)
+        return faiss.IndexIDMap(base_index)
+
+    def _prepare_vector(self, embedding: Any) -> np.ndarray:
+        array = np.asarray(embedding, dtype=np.float32)
+        if array.ndim == 1:
+            array = array.reshape(1, -1)
+        if array.ndim != 2:
+            raise ValueError("Embeddings must be 1D or 2D arrays")
+        if array.shape[1] != self.config.embedding_dimension:
+            raise ValueError(
+                "Embedding dimension mismatch: expected "
+                f"{self.config.embedding_dimension}, got {array.shape[1]}"
+            )
+        if self._normalize:
+            faiss.normalize_L2(array)
+        return array
+
+    def _generate_internal_id(self) -> int:
+        internal_id = self._next_internal_id
+        self._next_internal_id += 1
+        return internal_id
+
+    def _rebuild_index(self) -> None:
+        self._index = self._create_index()
+        if not self._documents:
+            return
+
+        vectors: list[np.ndarray] = []
+        ids: list[int] = []
+        for doc_id, document in self._documents.items():
+            internal_id = self._id_to_internal.get(doc_id)
+            if internal_id is None:
+                continue
+            vector = np.asarray(document.embedding, dtype=np.float32)
+            if vector.ndim == 1:
+                vector = vector.reshape(1, -1)
+            if self._normalize:
+                faiss.normalize_L2(vector)
+            vectors.append(vector)
+            ids.append(internal_id)
+
+        if vectors:
+            stacked = np.vstack(vectors)
+            id_array = np.asarray(ids, dtype=np.int64)
+            self._index.add_with_ids(stacked, id_array)
+
+    def _persist_state(self) -> None:
+        if self._index_path:
+            self._index_path.parent.mkdir(parents=True, exist_ok=True)
+            faiss.write_index(self._index, str(self._index_path))
+
+        if self._metadata_path:
+            self._metadata_path.parent.mkdir(parents=True, exist_ok=True)
+            payload = {
+                "id_to_internal": self._id_to_internal,
+                "next_internal_id": self._next_internal_id,
+                "documents": {
+                    doc_id: document.model_dump(mode="json")
+                    for doc_id, document in self._documents.items()
+                },
+            }
+            self._metadata_path.write_text(
+                json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+            )
+
+    def _load_state(self) -> None:
+        if self._metadata_path and self._metadata_path.exists():
+            data = json.loads(self._metadata_path.read_text(encoding="utf-8"))
+            id_map = data.get("id_to_internal", {})
+            self._id_to_internal = {k: int(v) for k, v in id_map.items()}
+            self._internal_to_id = {v: k for k, v in self._id_to_internal.items()}
+            self._next_internal_id = int(data.get("next_internal_id", 1))
+
+            documents = data.get("documents", {})
+            for doc_id, payload in documents.items():
+                document = Document.model_validate(payload)
+                self._documents[doc_id] = document
+
+        if self._index_path and self._index_path.exists():
+            self._index = faiss.read_index(str(self._index_path))
+            if not isinstance(self._index, faiss.IndexIDMap):
+                self._rebuild_index()
+        else:
+            self._rebuild_index()
+
+    def _resolve_metric(self, metric: str) -> str:
+        metric_lower = metric.lower()
+        if metric_lower in {"ip", "inner_product", "cosine"}:
+            return "ip"
+        return "l2"
+
+    def _score_from_distance(self, distance: float) -> float:
+        if self._metric == "ip":
+            return distance
+        return 1.0 / (1.0 + distance)
+
+    def _chunk_to_document(self, chunk: Chunk) -> Document:
+        metadata = {
+            "source": "chunk",
+            "chunk_id": chunk.id,
+            "chunk_start_index": chunk.start_index,
+            "chunk_end_index": chunk.end_index,
+            "chunk_token_count": chunk.token_count,
+        }
+        if chunk.context is not None:
+            metadata["chunk_context"] = chunk.context
+
+        embedding = None
+        if chunk.embedding is not None:
+            embedding = (
+                chunk.embedding.tolist()
+                if hasattr(chunk.embedding, "tolist")
+                else chunk.embedding
+            )
+
+        return Document(
+            id=chunk.id,
+            content=chunk.text,
+            metadata=metadata,
+            embedding=embedding,
+        )
+
+    @staticmethod
+    def _matches_filters(
+        metadata: dict[str, Any], filters: dict[str, Any]
+    ) -> bool:
+        for key, value in filters.items():
+            if isinstance(value, list):
+                if metadata.get(key) not in value:
+                    return False
+            else:
+                if metadata.get(key) != value:
+                    return False
+        return True
+
+
+__all__ = ["FaissVectorStore"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
   "neo4j>=6.0.2",
   "sentence-transformers>=5.1.1",
   "numpy>=2.2.6",
+  "faiss-cpu>=1.8.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_faiss_vector_store.py
+++ b/tests/test_faiss_vector_store.py
@@ -1,0 +1,189 @@
+"""Tests for the FAISS vector store backend."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+from DeepResearch.src.datatypes.chunk_dataclass import Chunk
+from DeepResearch.src.datatypes.rag import Document, Embeddings, SearchType
+from DeepResearch.src.vector_stores.faiss_config import FaissVectorStoreConfig
+from DeepResearch.src.vector_stores.faiss_vector_store import FaissVectorStore
+
+pytestmark = pytest.mark.asyncio
+
+
+class MockEmbeddings(Embeddings):
+    """Deterministic embedding generator for testing."""
+
+    def __init__(self, dimension: int = 8):
+        self.dimension = dimension
+
+    def _encode(self, text: str) -> list[float]:
+        vector = [0.05] * self.dimension
+        for index, character in enumerate(text[: self.dimension - 1]):
+            vector[index] = ((ord(character) % 256) + 1) / 300.0
+        vector[-1] = len(text) / 50.0 + 0.1
+        return vector
+
+    async def vectorize_documents(self, document_chunks: list[str]) -> list[list[float]]:
+        return [self._encode(text) for text in document_chunks]
+
+    def vectorize_documents_sync(self, document_chunks: list[str]) -> list[list[float]]:
+        return [self._encode(text) for text in document_chunks]
+
+    async def vectorize_query(self, text: str) -> list[float]:
+        return self._encode(text)
+
+    def vectorize_query_sync(self, text: str) -> list[float]:
+        return self._encode(text)
+
+
+@pytest.fixture
+def mock_embeddings() -> MockEmbeddings:
+    return MockEmbeddings(dimension=8)
+
+
+@pytest.fixture
+def faiss_config(tmp_path) -> FaissVectorStoreConfig:
+    index_path = tmp_path / "test_index.faiss"
+    metadata_path = tmp_path / "test_metadata.json"
+    return FaissVectorStoreConfig(
+        index_path=str(index_path),
+        metadata_path=str(metadata_path),
+        embedding_dimension=8,
+        distance_metric="cosine",
+    )
+
+
+@pytest_asyncio.fixture
+async def faiss_store(
+    faiss_config: FaissVectorStoreConfig, mock_embeddings: MockEmbeddings
+) -> Any:
+    store = FaissVectorStore(faiss_config, mock_embeddings)
+    try:
+        yield store
+    finally:
+        await store.close()
+
+
+async def test_add_and_search_documents(
+    faiss_store: FaissVectorStore,
+) -> None:
+    documents = [
+        Document(id="doc_alpha", content="Alpha gene research", metadata={"category": "science"}),
+        Document(id="doc_beta", content="Beta cell study", metadata={"category": "biology"}),
+    ]
+
+    await faiss_store.add_documents(documents)
+
+    results = await faiss_store.search(
+        "Alpha gene research", SearchType.SIMILARITY, top_k=2
+    )
+
+    assert results
+    assert results[0].document.id == "doc_alpha"
+    assert results[0].rank == 1
+    assert results[0].score > 0.0
+
+
+async def test_delete_documents_removes_from_index(
+    faiss_store: FaissVectorStore
+) -> None:
+    documents = [
+        Document(id="doc_alpha", content="Alpha gene research"),
+        Document(id="doc_beta", content="Beta cell study"),
+    ]
+    await faiss_store.add_documents(documents)
+
+    removed = await faiss_store.delete_documents(["doc_alpha"])
+    assert removed is True
+
+    results = await faiss_store.search("Alpha", SearchType.SIMILARITY, top_k=2)
+    assert all(result.document.id != "doc_alpha" for result in results)
+
+
+async def test_persistence_round_trip(tmp_path, mock_embeddings: MockEmbeddings) -> None:
+    config = FaissVectorStoreConfig(
+        index_path=str(tmp_path / "roundtrip.faiss"),
+        metadata_path=str(tmp_path / "roundtrip.json"),
+        embedding_dimension=8,
+        distance_metric="cosine",
+    )
+
+    store = FaissVectorStore(config, mock_embeddings)
+    await store.add_documents(
+        [Document(id="doc_alpha", content="Alpha gene research", metadata={"category": "science"})]
+    )
+    await store.close()
+
+    reloaded_store = FaissVectorStore(config, MockEmbeddings(dimension=8))
+    results = await reloaded_store.search("Alpha gene", SearchType.SIMILARITY, top_k=1)
+    assert results and results[0].document.id == "doc_alpha"
+    await reloaded_store.close()
+
+
+async def test_add_document_chunks(faiss_store: FaissVectorStore) -> None:
+    chunk = Chunk(text="Segment about proteins", start_index=0, end_index=21, token_count=4)
+
+    ids = await faiss_store.add_document_chunks([chunk])
+    assert ids == [chunk.id]
+
+    results = await faiss_store.search("proteins", SearchType.SIMILARITY, top_k=1)
+    assert results
+    assert results[0].document.metadata.get("source") == "chunk"
+    assert results[0].document.metadata.get("chunk_id") == chunk.id
+
+
+async def test_add_document_text_chunks_returns_ids(
+    faiss_store: FaissVectorStore
+) -> None:
+    ids = await faiss_store.add_document_text_chunks([
+        "Introductory passage",
+        "Detailed follow up",
+    ])
+
+    assert len(ids) == 2
+    assert ids[0] != ids[1]
+
+    results = await faiss_store.search("Detailed follow up", SearchType.SIMILARITY, top_k=2)
+    assert any(result.document.id == ids[1] for result in results)
+
+
+async def test_search_with_filters(faiss_store: FaissVectorStore) -> None:
+    documents = [
+        Document(id="doc_math", content="Algebra foundations", metadata={"category": "math"}),
+        Document(id="doc_science", content="Cellular biology basics", metadata={"category": "science"}),
+    ]
+    await faiss_store.add_documents(documents)
+
+    results = await faiss_store.search(
+        "foundations",
+        SearchType.SIMILARITY,
+        top_k=5,
+        filters={"category": "math"},
+    )
+
+    assert len(results) == 1
+    assert results[0].document.id == "doc_math"
+
+
+async def test_update_document_replaces_embedding(
+    faiss_store: FaissVectorStore
+) -> None:
+    original = Document(id="doc_alpha", content="Alpha gene research")
+    await faiss_store.add_documents([original])
+
+    updated = Document(id="doc_alpha", content="Gamma protein analysis", metadata={"category": "science"})
+    update_result = await faiss_store.update_document(updated)
+    assert update_result is True
+
+    stored = await faiss_store.get_document("doc_alpha")
+    assert stored is not None
+    assert stored.content == "Gamma protein analysis"
+    assert stored.metadata.get("category") == "science"
+
+    results = await faiss_store.search("Gamma protein analysis", SearchType.SIMILARITY, top_k=1)
+    assert results and results[0].document.id == "doc_alpha"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -870,6 +870,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
+    { name = "faiss-cpu" },
     { name = "fastmcp" },
     { name = "gradio" },
     { name = "hydra-core" },
@@ -927,6 +928,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.2" },
+    { name = "faiss-cpu", specifier = ">=1.8.0" },
     { name = "fastmcp", specifier = ">=2.12.4" },
     { name = "gradio", specifier = ">=5.47.2" },
     { name = "hydra-core", specifier = ">=1.3.2" },
@@ -1090,6 +1092,65 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "faiss-cpu"
+version = "1.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/80/bb75a7ed6e824dea452a24d3434a72ed799324a688b10b047d441d270185/faiss_cpu-1.12.0.tar.gz", hash = "sha256:2f87cbcd603f3ed464ebceb857971fdebc318de938566c9ae2b82beda8e953c0", size = 69292, upload-time = "2025-08-13T06:07:26.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/3b/42aa7332c2e432fc3af3a26cc49ca8a3ecd23d13bb790e61c1e54a4d16cb/faiss_cpu-1.12.0-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:be96f9290edd13d56fb3c69b8dd6be487552b4401f2e95b437cabf5309c424ad", size = 8006082, upload-time = "2025-08-13T06:05:33.131Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ab/9959c2d9c3a511a5dbfa4e2e2a1d0bdcad5929d410b3abe87bbed74dcb9b/faiss_cpu-1.12.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:0834c547c39d5e5d0b769c90ac5d5ca42e00bcdbba491f3440d2d458058b19d6", size = 3360138, upload-time = "2025-08-13T06:05:35.003Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b9/7456f89effe93b7693c7e39cd365065e27aa31794442510c44ad8cce6c4c/faiss_cpu-1.12.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a40830a16d8718b14a462e1a1efaa26660eb3bb8ada22e0712a6ac181092750e", size = 3825459, upload-time = "2025-08-13T06:05:36.546Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/0f/02d5d2ae8b53e5629cb03fbd871bbbfbbd647ffc3d09393b34f6347072d7/faiss_cpu-1.12.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d7f8732796e3f730556e99327861066ead0ae7e66b5cbf6c0f217be48074e41e", size = 31425823, upload-time = "2025-08-13T06:05:38.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/a9fcb0b82727ab2d5509caa7637e5d345c710502f68c7a7e90dd212654ad/faiss_cpu-1.12.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ded5063e13c3bb6b1b463827f838ae45a0aea4c9aeaf6c938e7e87f3f6ea4126", size = 9751939, upload-time = "2025-08-13T06:05:41.816Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/25/7efcb5856f9df4c003716687c4604bb5cfc44819539b79d60e302018962b/faiss_cpu-1.12.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8e74e71249165757a12fb02feee67ea95df542bcafa21b449fbd2ed0c31b48b4", size = 24160951, upload-time = "2025-08-13T06:05:44.243Z" },
+    { url = "https://files.pythonhosted.org/packages/34/d4/1f1cc444708b426b42ec52f01c735d91cb9775fe55cf3d2c64b9a6fd8792/faiss_cpu-1.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:d04d1cae2a9b66083cd8f48ff391731d81e0a1fdf67ab5c33ae10b3a22a0caae", size = 18169601, upload-time = "2025-08-13T06:05:46.558Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ed/83fed257ea410c2e691374f04ac914d5f9414f04a9c7a266bdfbb999eb16/faiss_cpu-1.12.0-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:fbb63595c7ad43c0d9caaf4d554a38a30ea4edda5e7c3ed38845562776992ba9", size = 8006079, upload-time = "2025-08-13T06:05:48.932Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/07/80c248db87ef2e753ad390fca3b0d7dd6092079e904f35b248c7064e791e/faiss_cpu-1.12.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:83e74cbde6fa5caceec5bc103c82053d50fde163e3ceabaa58c91508e984142b", size = 3360138, upload-time = "2025-08-13T06:05:50.873Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/22/73bd9ed7b11cd14eb0da6e2f2eae763306abaad1b25a5808da8b1fc07665/faiss_cpu-1.12.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6155a5138604b702a32f8f0a63948a539eb7468898554a9911f9ab8c899284fb", size = 3825466, upload-time = "2025-08-13T06:05:52.311Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/7f/e1a21337b3cba24b953c760696e3b188a533d724440e050fd60a3c1aa919/faiss_cpu-1.12.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1bf4b5f0e9b6bb5a566b1a31e84a93b283f26c2b0155fb2eb5970c32a540a906", size = 31425626, upload-time = "2025-08-13T06:05:54.155Z" },
+    { url = "https://files.pythonhosted.org/packages/05/24/f352cf8400f414e6a31385ef12d43d11aac8beb11d573a2fd00ec44b8cb7/faiss_cpu-1.12.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:60a535b79d3d6225c7c21d7277fb0c6fde80c46a9c1e33632b1b293c1d177f30", size = 9751949, upload-time = "2025-08-13T06:05:56.369Z" },
+    { url = "https://files.pythonhosted.org/packages/05/50/a122e3076d7fd95cbe9a0cdf0fc796836f1e4fd399b418c6ba8533c75770/faiss_cpu-1.12.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0d1b243468a24564f85a41166f2ca4c92f8f6755da096ffbdcf551675ca739c5", size = 24161021, upload-time = "2025-08-13T06:05:58.776Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9f/3344f6fe69f6fbfb19dec298b4dda3d47a87dc31e418911fdcc3a3ace013/faiss_cpu-1.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:84510079a2efe954e6b89fe5e62f23a98c1ef999756565e056f95f835ff43c5e", size = 18169278, upload-time = "2025-08-13T06:06:01.44Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/b1/37d532292c1b3dab690636947a532d3797741b09f2dfb9cb558ffeaff34b/faiss_cpu-1.12.0-cp311-cp311-win_arm64.whl", hash = "sha256:2283f1014f7f86dd56b53bf0ea0d7f848eb4c9c6704b8f4f99a0af02e994e479", size = 8007093, upload-time = "2025-08-13T06:06:03.904Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/58/602ed184d35742eb240cbfea237bd214f2ae7f01cb369c39f4dff392f7c9/faiss_cpu-1.12.0-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:9b54990fcbcf90e37393909d4033520237194263c93ab6dbfae0616ef9af242b", size = 8034413, upload-time = "2025-08-13T06:06:05.564Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d5/f84c3d0e022cdeb73ff8406a6834a7698829fa242eb8590ddf8a0b09357f/faiss_cpu-1.12.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:a5f5bca7e1a3e0a98480d1e2748fc86d12c28d506173e460e6746886ff0e08de", size = 3362034, upload-time = "2025-08-13T06:06:07.091Z" },
+    { url = "https://files.pythonhosted.org/packages/19/89/a4ba4d285ea4f9b0824bf31ebded3171da08bfcf5376f4771cc5481f72cd/faiss_cpu-1.12.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:016e391f49933875b8d60d47f282f2e93d8ea9f9ffbda82467aa771b11a237db", size = 3834319, upload-time = "2025-08-13T06:06:08.86Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/c9/be4e52fd96be601fefb313c26e1259ac2e6b556fb08cc392db641baba8c7/faiss_cpu-1.12.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2e4963c7188f57cfba248f09ebd8a14c76b5ffb87382603ccd4576f2da39d74", size = 31421585, upload-time = "2025-08-13T06:06:10.643Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/aa/12c6723ce30df721a6bace21398559c0367c5418c04139babc2d26d8d158/faiss_cpu-1.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:88bfe134f8c7cd2dda7df34f2619448906624962c8207efdd6eb1647e2f5338b", size = 9762449, upload-time = "2025-08-13T06:06:13.373Z" },
+    { url = "https://files.pythonhosted.org/packages/67/15/ed2c9de47c3ebae980d6938f0ec12d739231438958bc5ab2d636b272d913/faiss_cpu-1.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9243ee4c224a0d74419040503f22bf067462a040281bf6f3f107ab205c97d438", size = 24156525, upload-time = "2025-08-13T06:06:15.307Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b8/6911de6b8fdcfa76144680c2195df6ce7e0cc920a8be8c5bbd2dfe5e3c37/faiss_cpu-1.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:6b8012353d50d9bc81bcfe35b226d0e5bfad345fdebe0da31848395ebc83816d", size = 18169636, upload-time = "2025-08-13T06:06:17.613Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/69/d2b0f434b0ae35344280346b58d2b9a251609333424f3289c54506e60c51/faiss_cpu-1.12.0-cp312-cp312-win_arm64.whl", hash = "sha256:8b4f5b18cbe335322a51d2785bb044036609c35bfac5915bff95eadc10e89ef1", size = 8012423, upload-time = "2025-08-13T06:06:19.73Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/4e/6be5fbd2ceccd87b168c64edeefa469cd11f095bb63b16a61a29296b0fdb/faiss_cpu-1.12.0-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:c9c79b5f28dcf9b2e2557ce51b938b21b7a9d508e008dc1ffea7b8249e7bd443", size = 8034409, upload-time = "2025-08-13T06:06:22.519Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f0/658012a91a690d82f3587fd8e56ea1d9b9698c31970929a9dba17edd211e/faiss_cpu-1.12.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:0db6485bc9f32b69aaccf9ad520782371a79904dcfe20b6da5cbfd61a712e85f", size = 3362034, upload-time = "2025-08-13T06:06:24.052Z" },
+    { url = "https://files.pythonhosted.org/packages/81/8b/9b355309d448e1a737fac31d45e9b2484ffb0f04f10fba3b544efe6661e4/faiss_cpu-1.12.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6db5532831791d7bac089fc580e741e99869122946bb6a5f120016c83b95d10", size = 3834324, upload-time = "2025-08-13T06:06:25.506Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/31/d229f6cdb9cbe03020499d69c4b431b705aa19a55aa0fe698c98022b2fef/faiss_cpu-1.12.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d57ed7aac048b18809af70350c31acc0fb9f00e6c03b6ed1651fd58b174882d", size = 31421590, upload-time = "2025-08-13T06:06:27.601Z" },
+    { url = "https://files.pythonhosted.org/packages/26/19/80289ba008f14c95fbb6e94617ea9884e421ca745864fe6b8b90e1c3fc94/faiss_cpu-1.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:26c29290e7d1c5938e5886594dc0a2272b30728351ca5f855d4ae30704d5a6cc", size = 9762452, upload-time = "2025-08-13T06:06:30.237Z" },
+    { url = "https://files.pythonhosted.org/packages/af/e7/6cc03ead5e19275e34992419e2b7d107d0295390ccf589636ff26adb41e2/faiss_cpu-1.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9b43d0c295e93a8e5f1dd30325caaf34d4ecb51f1e3d461c7b0e71bff3a8944b", size = 24156530, upload-time = "2025-08-13T06:06:32.23Z" },
+    { url = "https://files.pythonhosted.org/packages/34/90/438865fe737d65e7348680dadf3b2983bdcef7e5b7e852000e74c50a9933/faiss_cpu-1.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:a7c6156f1309bb969480280906e8865c3c4378eebb0f840c55c924bf06efd8d3", size = 18169604, upload-time = "2025-08-13T06:06:34.884Z" },
+    { url = "https://files.pythonhosted.org/packages/76/69/40a1d8d781a70d33c57ef1b4b777486761dd1c502a86d27e90ef6aa8a9f9/faiss_cpu-1.12.0-cp313-cp313-win_arm64.whl", hash = "sha256:0b5fac98a350774a98b904f7a7c6689eb5cf0a593d63c552e705a80c55636d15", size = 8012523, upload-time = "2025-08-13T06:06:37.24Z" },
+    { url = "https://files.pythonhosted.org/packages/12/35/01a4a7c179d67bee0d8a027b95c3eae19cb354ae69ef2bc50ac3b93bc853/faiss_cpu-1.12.0-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:ff7db774968210d08cd0331287f3f66a6ffef955a7aa9a7fcd3eb4432a4ce5f5", size = 8036142, upload-time = "2025-08-13T06:06:38.894Z" },
+    { url = "https://files.pythonhosted.org/packages/08/23/bac2859490096608c9d527f3041b44c2e43f8df0d4aadd53a4cc5ce678ac/faiss_cpu-1.12.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:220b5bb5439c64e417b35f9ade4c7dc3bf7df683d6123901ba84d6d764ecd486", size = 3363747, upload-time = "2025-08-13T06:06:40.73Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1d/e18023e1f43a18ec593adcd69d356f1fa94bde20344e38334d5985e5c5cc/faiss_cpu-1.12.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:693d0bf16f79e8d16a1baaeda459f3375f37da0354e97dc032806b48a2a54151", size = 3835232, upload-time = "2025-08-13T06:06:42.172Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2b/1c1fea423d3f550f44c5ec3f14d8400919b49c285c3bd146687c63e40186/faiss_cpu-1.12.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bcc6587dee21e17430fb49ddc5200625d6f5e1de2bdf436f14827bad4ca78d19", size = 31432677, upload-time = "2025-08-13T06:06:44.348Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d2/3483e92a02f30e2d8491a256f470f54b7f5483266dfe09126d28741d31ec/faiss_cpu-1.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b80e5965f001822cc99ec65c715169af1b70bdae72eccd573520a2dec485b3ee", size = 9765504, upload-time = "2025-08-13T06:06:46.567Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/2f/d97792211a9bd84b8d6b1dcaa1dcd69ac11e026c6ef19c641b6a87e31025/faiss_cpu-1.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:98279f1b4876ef9902695a329b81a99002782ab6e26def472022009df6f1ac68", size = 24169930, upload-time = "2025-08-13T06:06:48.916Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b8/b707ca4d88af472509a053c39d3cced53efd19d096b8dff2fadc18c4b82d/faiss_cpu-1.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:11670337f9f5ee9ff3490e30683eea80add060c300cf6f6cb0e8faf3155fd20e", size = 18475400, upload-time = "2025-08-13T06:06:51.233Z" },
+    { url = "https://files.pythonhosted.org/packages/77/11/42e41ddebde4dfe77e36e92d0110b4f733c8640883abffde54f802482deb/faiss_cpu-1.12.0-cp314-cp314-win_arm64.whl", hash = "sha256:7ac1c8b53609b5c722ab60f1749260a7cb3c72fdfb720a0e3033067e73591da5", size = 8281229, upload-time = "2025-08-13T06:06:53.735Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/8ae5bbeabe70eb673c37fc7c77e2e476746331afb6654b2df97d8b6d380d/faiss_cpu-1.12.0-cp314-cp314t-macosx_13_0_x86_64.whl", hash = "sha256:110b21b7bb4c93c4f1a5eb2ffb8ef99dcdb4725f8ab2e5cd161324e4d981f204", size = 8087247, upload-time = "2025-08-13T06:06:55.407Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/df/b3d79098860b67b126da351788c04ac243c29718dadc4a678a6f5e7209c0/faiss_cpu-1.12.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:82eb5515ce72be9a43f4cf74447a0d090e014231981df91aff7251204b506fbf", size = 3411043, upload-time = "2025-08-13T06:06:56.983Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/2f/b1a2a03dd3cce22ff9fc434aa3c7390125087260c1d1349311da36eaa432/faiss_cpu-1.12.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:754eef89cdf2b35643df6b0923a5a098bdfecf63b5f4bd86c385042ee511b287", size = 3801789, upload-time = "2025-08-13T06:06:58.688Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/a8/16ad0c6a966e93d04bfd5248d2be1d8b5849842b0e2611c5ecd26fcaf036/faiss_cpu-1.12.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7285c71c8f5e9c58b55175f5f74c78c518c52c421a88a430263f34e3e31f719c", size = 31231388, upload-time = "2025-08-13T06:07:00.55Z" },
+    { url = "https://files.pythonhosted.org/packages/62/a1/9c16eca0b8f8b13c32c47a5e4ff7a4bc0ca3e7d263140312088811230871/faiss_cpu-1.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:84a50d7a2f711f79cc8b65aa28956dba6435e47b71a38b2daea44c94c9b8e458", size = 9737605, upload-time = "2025-08-13T06:07:03.018Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/4a/2c2d615078c9d816a836fb893aaef551ad152f2eb00bc258698273c240c0/faiss_cpu-1.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f3e0a14e4edec6a3959a9f51afccb89e863138f184ff2cc24c13f9ad788740b", size = 23922880, upload-time = "2025-08-13T06:07:05.099Z" },
+    { url = "https://files.pythonhosted.org/packages/30/aa/99b8402a4dac678794f13f8f4f29d666c2ef0a91594418147f47034ebc81/faiss_cpu-1.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8b3239cc371df6826ac43c62ac04eec7cc497bedb43f681fcd8ea494f520ddbb", size = 18750661, upload-time = "2025-08-13T06:07:07.551Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/a2/b546e9a20ba157eb2fbe141289f1752f157ee6d932899f4853df4ded6d4b/faiss_cpu-1.12.0-cp314-cp314t-win_arm64.whl", hash = "sha256:58b23456db725ee1bd605a6135d2ef55b2ac3e0b6fe873fd99a909e8ef4bd0ff", size = 8302032, upload-time = "2025-08-13T06:07:09.602Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- implement a FAISS-backed vector store with persistence and metadata management
- expose the FAISS store through the vector store factory and configuration helpers
- add the faiss-cpu dependency and comprehensive async pytest coverage for the new backend

## Testing
- pytest tests/test_faiss_vector_store.py

For https://github.com/DeepCritical/DeepCritical/issues/3