### PR TITLE
Wire FAISS vector store through RAG pipeline

### DIFF
--- a/DeepResearch/src/agents/rag_agent.py
+++ b/DeepResearch/src/agents/rag_agent.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 
 from ..datatypes.rag import (
     Document,
@@ -33,32 +33,39 @@ class RAGAgent(ResearchAgent):
         self,
         vector_store_config: VectorStoreConfig | None = None,
         embeddings: Embeddings | None = None,
+        *,
+        vector_store: VectorStore | None = None,
     ):
         super().__init__()
         self.agent_type = "rag"
-        self.vector_store: VectorStore | None = None
+        self.vector_store: VectorStore | None = vector_store
         self.embeddings: Embeddings | None = embeddings
+
+        if vector_store is not None and vector_store_config is not None:
+            msg = "Provide either an existing vector store or a configuration, not both"
+            raise ValueError(msg)
 
         if vector_store_config and embeddings:
             self.vector_store = create_vector_store(vector_store_config, embeddings)
         elif vector_store_config and not embeddings:
-            raise ValueError(
-                "Embeddings must be provided when vector_store_config is specified"
-            )
-        elif embeddings and not vector_store_config:
-            raise ValueError(
-                "Vector store config must be provided when embeddings is specified"
-            )
+            msg = "Embeddings must be provided when vector_store_config is specified"
+            raise ValueError(msg)
+        elif embeddings and not vector_store_config and vector_store is None:
+            msg = "Vector store config must be provided when embeddings is specified"
+            raise ValueError(msg)
 
-    def execute_rag_query(self, query: RAGQuery) -> RAGResponse:
+    async def execute_rag_query(self, query: RAGQuery) -> RAGResponse:
         """Execute a RAG query and return the response."""
         start_time = time.time()
 
         try:
-            # Retrieve relevant documents
-            retrieved_documents = self.retrieve_documents(query.text, query.top_k or 5)
+            retrieved_documents = await self.retrieve_documents(
+                query.text,
+                limit=query.top_k or 5,
+                search_type=query.search_type,
+                filters=query.filters,
+            )
 
-            # Generate answer based on retrieved documents
             context = self._build_context(retrieved_documents)
             generated_answer = self.generate_answer(query.text, retrieved_documents)
 
@@ -78,112 +85,122 @@ class RAGAgent(ResearchAgent):
                 },
                 processing_time=processing_time,
             )
-        except Exception as e:
+        except Exception as exc:
             processing_time = time.time() - start_time
             return RAGResponse(
                 query=query.text,
                 retrieved_documents=[],
-                generated_answer=f"Error during RAG processing: {e!s}",
+                generated_answer=f"Error during RAG processing: {exc!s}",
                 context="",
-                metadata={"status": "error", "error": str(e)},
+                metadata={"status": "error", "error": str(exc)},
                 processing_time=processing_time,
             )
 
-    def retrieve_documents(self, query: str, limit: int = 5) -> list[Document]:
+    async def retrieve_documents(
+        self,
+        query: str,
+        *,
+        limit: int = 5,
+        search_type: SearchType = SearchType.SIMILARITY,
+        filters: dict[str, Any] | None = None,
+    ) -> list[SearchResult]:
         """Retrieve relevant documents for a query."""
+
         if not self.vector_store:
             return []
 
         try:
-            # Perform similarity search
-            search_results = self.vector_store.search(
+            search_results = await self.vector_store.search(
                 query=query,
-                search_type=SearchType.SIMILARITY,
+                search_type=search_type,
+                top_k=limit,
+                filters=filters,
             )
-
-            # Convert SearchResult to Document
-            documents = []
-            for result in search_results[:limit]:
-                documents.append(result.document)
-
-            return documents
-        except Exception as e:
-            print(f"Error during document retrieval: {e}")
+            return search_results[:limit]
+        except Exception as exc:  # pragma: no cover - logged for debugging
+            print(f"Error during document retrieval: {exc}")
             return []
 
-    def generate_answer(self, query: str, documents: list[Document]) -> str:
+    def generate_answer(self, query: str, results: list[SearchResult]) -> str:
         """Generate an answer based on retrieved documents."""
-        if not documents:
+
+        if not results:
             return "No relevant documents found to answer the query."
 
-        # For now, return a simple concatenation
-        # In a real implementation, this would use an LLM to generate an answer
         doc_summaries = []
-        for i, doc in enumerate(documents, 1):
+        for index, result in enumerate(results, 1):
+            doc = result.document
             content_preview = (
                 doc.content[:200] + "..." if len(doc.content) > 200 else doc.content
             )
-            doc_summaries.append(f"Document {i}: {content_preview}")
+            doc_summaries.append(f"Document {index}: {content_preview}")
 
-        return f"""Based on the retrieved documents, here's what I found regarding: "{query}"
+        return (
+            f"Based on the retrieved documents, here's what I found regarding: "
+            f'"{query}"\n\nContext from {len(results)} documents:\n'
+            f"{chr(10).join(doc_summaries)}\n\nNote: This is a basic implementation. "
+            "A full RAG system would use an LLM to generate a more coherent and "
+            "contextual answer based on the retrieved documents."
+        )
 
-Context from {len(documents)} documents:
-{chr(10).join(doc_summaries)}
-
-Note: This is a basic implementation. A full RAG system would use an LLM to generate a more coherent and contextual answer based on the retrieved documents."""
-
-    def _build_context(self, documents: list[Document]) -> str:
+    def _build_context(self, results: list[SearchResult]) -> str:
         """Build context string from retrieved documents."""
-        if not documents:
+
+        if not results:
             return ""
 
         context_parts = []
-        for i, doc in enumerate(documents, 1):
-            context_parts.append(f"[Document {i}]\n{doc.content}\n")
+        for index, result in enumerate(results, 1):
+            context_parts.append(f"[Document {index}]\n{result.document.content}\n")
 
         return "\n".join(context_parts)
 
-    def add_documents(self, documents: list[Document]) -> bool:
+    async def add_documents(self, documents: list[Document]) -> bool:
         """Add documents to the vector store."""
+
         if not self.vector_store:
             raise ValueError("Vector store not configured")
 
         try:
-            self.vector_store.add_documents(documents)
+            await self.vector_store.add_documents(documents)
             return True
-        except Exception as e:
-            print(f"Error adding documents: {e}")
+        except Exception as exc:  # pragma: no cover - logged for debugging
+            print(f"Error adding documents: {exc}")
             return False
 
-    def add_document_chunks(self, chunks: list[Document]) -> bool:
+    async def add_document_chunks(self, chunks: list[Document]) -> bool:
         """Add document chunks to the vector store."""
+
         if not self.vector_store:
             raise ValueError("Vector store not configured")
 
         try:
-            # Convert Document chunks to proper format if needed
-            # Assuming chunks are Document objects with chunked content
-            self.vector_store.add_documents(chunks)
+            await self.vector_store.add_documents(chunks)
             return True
-        except Exception as e:
-            print(f"Error adding document chunks: {e}")
+        except Exception as exc:  # pragma: no cover - logged for debugging
+            print(f"Error adding document chunks: {exc}")
             return False
 
-    def search_documents(
+    async def search_documents(
         self,
         query: str,
         search_type: SearchType = SearchType.SIMILARITY,
         limit: int = 10,
+        filters: dict[str, Any] | None = None,
     ) -> list[SearchResult]:
         """Search documents in the vector store."""
+
         if not self.vector_store:
             return []
 
         try:
-            return self.vector_store.search(
+            results = await self.vector_store.search(
                 query=query,
                 search_type=search_type,
-            )[:limit]
-        except Exception as e:
-            print(f"Error searching documents: {e}")
+                top_k=limit,
+                filters=filters,
+            )
+            return results[:limit]
+        except Exception as exc:  # pragma: no cover - logged for debugging
+            print(f"Error searching documents: {exc}")
             return []

--- a/DeepResearch/src/datatypes/__init__.py
+++ b/DeepResearch/src/datatypes/__init__.py
@@ -82,6 +82,7 @@ from .coding_base import (
     CommandLineCodeResult,
     IPythonCodeResult,
 )
+from .chunking import ChunkingConfig
 from .deep_agent_tools import (
     EditFileRequest,
     EditFileResponse,
@@ -289,6 +290,7 @@ __all__ = [
     "ChatResponse",
     "ChatResponseUpdate",
     "CitationAnnotation",
+    "ChunkingConfig",
     "CodeBlock",
     "CodeExecBuiltinRunner",
     "CodeExecutionConfig",

--- a/DeepResearch/src/datatypes/chunking.py
+++ b/DeepResearch/src/datatypes/chunking.py
@@ -1,0 +1,39 @@
+"""Chunking configuration utilities for RAG workflows."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class ChunkingConfig(BaseModel):
+    """Configuration describing how documents should be chunked."""
+
+    chunk_size: int = Field(
+        1000,
+        ge=1,
+        description="Maximum number of characters per chunk.",
+    )
+    chunk_overlap: int = Field(
+        200,
+        ge=0,
+        description="Number of overlapping characters between consecutive chunks.",
+    )
+
+    @model_validator(mode="after")
+    def validate_overlap(self) -> "ChunkingConfig":
+        """Ensure the configured overlap cannot exceed the chunk size."""
+
+        if self.chunk_overlap >= self.chunk_size:
+            msg = "chunk_overlap must be smaller than chunk_size"
+            raise ValueError(msg)
+        return self
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "chunk_size": 1000,
+                "chunk_overlap": 200,
+            }
+        }
+    )
+

--- a/DeepResearch/src/datatypes/rag.py
+++ b/DeepResearch/src/datatypes/rag.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, ConfigDict, Field, HttpUrl, model_validator
 
 # Import existing dataclasses for alignment
 from .chunk_dataclass import Chunk, generate_id
+from .chunking import ChunkingConfig
 from .document_dataclass import Document as ChonkieDocument
 
 if TYPE_CHECKING:
@@ -456,8 +457,10 @@ class RAGConfig(BaseModel):
     vector_store: VectorStoreConfig = Field(
         ..., description="Vector store configuration"
     )
-    chunk_size: int = Field(1000, description="Document chunk size for processing")
-    chunk_overlap: int = Field(200, description="Overlap between chunks")
+    chunking: ChunkingConfig = Field(
+        default_factory=ChunkingConfig,
+        description="Chunking configuration for document processing",
+    )
     max_context_length: int = Field(4000, description="Maximum context length for LLM")
     enable_reranking: bool = Field(False, description="Enable document reranking")
     reranker_model: str | None = Field(None, description="Reranker model name")
@@ -465,7 +468,8 @@ class RAGConfig(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def validate_config(cls, values):
-        """Validate RAG configuration."""
+        """Validate RAG configuration and normalize chunking settings."""
+
         embeddings = values.get("embeddings")
         vector_store = values.get("vector_store")
 
@@ -478,7 +482,34 @@ class RAGConfig(BaseModel):
                 )
                 raise ValueError(msg)
 
+        # Allow legacy chunk_size/chunk_overlap inputs while moving to ChunkingConfig
+        chunking_values = values.get("chunking")
+        if isinstance(chunking_values, ChunkingConfig):
+            chunking: dict[str, Any] = chunking_values.model_dump()
+        elif isinstance(chunking_values, dict):
+            chunking = dict(chunking_values)
+        else:
+            chunking = {}
+
+        if "chunk_size" in values and "chunk_size" not in chunking:
+            chunking["chunk_size"] = values["chunk_size"]
+        if "chunk_overlap" in values and "chunk_overlap" not in chunking:
+            chunking["chunk_overlap"] = values["chunk_overlap"]
+        values["chunking"] = chunking
+
         return values
+
+    @property
+    def chunk_size(self) -> int:
+        """Backwards-compatible access to chunk size."""
+
+        return self.chunking.chunk_size
+
+    @property
+    def chunk_overlap(self) -> int:
+        """Backwards-compatible access to chunk overlap."""
+
+        return self.chunking.chunk_overlap
 
     model_config = ConfigDict(
         json_schema_extra={
@@ -495,8 +526,7 @@ class RAGConfig(BaseModel):
                     "port": 8000,
                 },
                 "vector_store": {"store_type": "chroma", "embedding_dimension": 1536},
-                "chunk_size": 1000,
-                "chunk_overlap": 200,
+                "chunking": {"chunk_size": 1000, "chunk_overlap": 200},
             }
         }
     )

--- a/DeepResearch/src/datatypes/vllm_integration.py
+++ b/DeepResearch/src/datatypes/vllm_integration.py
@@ -20,8 +20,13 @@ from .rag import (
     EmbeddingsConfig,
     LLMModelType,
     LLMProvider,
+    RAGConfig,
+    VectorStore,
+    VectorStoreConfig,
+    VectorStoreType,
     VLLMConfig,
 )
+from DeepResearch.src.vector_stores import create_vector_store
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -396,11 +401,19 @@ class VLLMDeployment(BaseModel):
 class VLLMRAGSystem(BaseModel):
     """VLLM-based RAG system implementation."""
 
-    deployment: VLLMDeployment = Field(..., description="VLLM deployment configuration")
-    embeddings: VLLMEmbeddings | None = Field(
-        None, description="VLLM embeddings provider"
+    deployment: VLLMDeployment = Field(
+        ..., description="VLLM deployment configuration"
+    )
+    rag_config: RAGConfig | None = Field(
+        None, description="Resolved RAG configuration for the current workflow"
+    )
+    embeddings: Embeddings | None = Field(
+        None, description="Embeddings provider used for vector operations"
     )
     llm: VLLMLLMProvider | None = Field(None, description="VLLM LLM provider")
+    vector_store: VectorStore | None = Field(
+        None, description="Backing vector store instance"
+    )
 
     async def initialize(self) -> None:
         """Initialize the VLLM RAG system."""
@@ -408,7 +421,7 @@ class VLLMRAGSystem(BaseModel):
         await self.deployment.wait_for_servers()
 
         # Initialize embeddings if embedding server is configured
-        if self.deployment.embedding_config:
+        if self.embeddings is None and self.deployment.embedding_config:
             embedding_config = EmbeddingsConfig(
                 model_type=EmbeddingModelType.CUSTOM,
                 model_name=self.deployment.embedding_config.model_name,
@@ -416,6 +429,9 @@ class VLLMRAGSystem(BaseModel):
                 num_dimensions=384,  # Default for sentence-transformers models
             )
             self.embeddings = VLLMEmbeddings(embedding_config)
+
+        if self.embeddings is None and self.rag_config:
+            self.embeddings = DeterministicEmbeddings(self.rag_config.embeddings)
 
         # Initialize LLM provider
         llm_config = VLLMConfig(
@@ -426,4 +442,61 @@ class VLLMRAGSystem(BaseModel):
         )
         self.llm = VLLMLLMProvider(llm_config)
 
+        if self.rag_config and self.vector_store is None:
+            if self.embeddings is None:
+                msg = "Embeddings provider must be initialized before vector store creation"
+                raise RuntimeError(msg)
+
+            self.vector_store = create_vector_store(
+                self._ensure_vector_store_config(self.rag_config.vector_store),
+                self.embeddings,
+            )
+
     model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    @staticmethod
+    def _ensure_vector_store_config(
+        config: VectorStoreConfig,
+    ) -> VectorStoreConfig:
+        """Ensure FAISS configs have persistence paths when missing."""
+
+        if config.store_type is VectorStoreType.FAISS:
+            updates: dict[str, str] = {}
+            if getattr(config, "index_path", None) is None:
+                updates["index_path"] = ":memory:"
+            if getattr(config, "metadata_path", None) is None:
+                updates["metadata_path"] = ":memory:"
+            if updates:
+                return config.model_copy(update=updates)
+        return config
+
+
+class DeterministicEmbeddings(Embeddings):
+    """Deterministic embedding provider used for local workflows and tests."""
+
+    def __init__(self, config: EmbeddingsConfig):
+        super().__init__(config)
+
+    def _encode(self, text: str) -> list[float]:
+        dimension = max(self.config.num_dimensions, 8)
+        vector = [0.0] * dimension
+        for index, character in enumerate(text[: dimension - 1]):
+            vector[index] = ((ord(character) % 256) + 1) / 255.0
+        vector[-1] = min(len(text) / 100.0, 1.0)
+        return vector
+
+    async def vectorize_documents(
+        self, document_chunks: list[str]
+    ) -> list[list[float]]:
+        return [self._encode(text) for text in document_chunks]
+
+    async def vectorize_query(self, text: str) -> list[float]:
+        return self._encode(text)
+
+    def vectorize_documents_sync(
+        self, document_chunks: list[str]
+    ) -> list[list[float]]:
+        return [self._encode(text) for text in document_chunks]
+
+    def vectorize_query_sync(self, text: str) -> list[float]:
+        return self._encode(text)

--- a/DeepResearch/src/statemachines/rag_workflow.py
+++ b/DeepResearch/src/statemachines/rag_workflow.py
@@ -109,6 +109,8 @@ class InitializeRAG(BaseNode[RAGState]):  # type: ignore[unsupported-base]
             VectorStoreType,
             VLLMConfig,
         )
+        from DeepResearch.src.datatypes.chunking import ChunkingConfig
+        from DeepResearch.src.vector_stores.faiss_config import FaissVectorStoreConfig
 
         # Create embeddings config
         embeddings_cfg = rag_cfg.get("embeddings", {})
@@ -135,22 +137,48 @@ class InitializeRAG(BaseNode[RAGState]):  # type: ignore[unsupported-base]
 
         # Create vector store config
         vs_cfg = rag_cfg.get("vector_store", {})
-        vector_store_config = VectorStoreConfig(
-            store_type=VectorStoreType(vs_cfg.get("store_type", "chroma")),
-            connection_string=vs_cfg.get("connection_string"),
-            host=vs_cfg.get("host", "localhost"),
-            port=vs_cfg.get("port", 8000),
-            database=vs_cfg.get("database"),
-            collection_name=vs_cfg.get("collection_name", "research_docs"),
-            embedding_dimension=embeddings_config.num_dimensions,
+        store_type = VectorStoreType(vs_cfg.get("store_type", "chroma"))
+        if store_type is VectorStoreType.FAISS:
+            vector_store_config = FaissVectorStoreConfig(
+                store_type=store_type,
+                connection_string=vs_cfg.get("connection_string"),
+                host=vs_cfg.get("host"),
+                port=vs_cfg.get("port"),
+                database=vs_cfg.get("database"),
+                collection_name=vs_cfg.get("collection_name", "research_docs"),
+                embedding_dimension=embeddings_config.num_dimensions,
+                distance_metric=vs_cfg.get("distance_metric", "cosine"),
+                index_path=vs_cfg.get("index_path"),
+                metadata_path=vs_cfg.get("metadata_path"),
+                normalize_vectors=vs_cfg.get("normalize_vectors"),
+            )
+        else:
+            vector_store_config = VectorStoreConfig(
+                store_type=store_type,
+                connection_string=vs_cfg.get("connection_string"),
+                host=vs_cfg.get("host", "localhost"),
+                port=vs_cfg.get("port", 8000),
+                database=vs_cfg.get("database"),
+                collection_name=vs_cfg.get("collection_name", "research_docs"),
+                embedding_dimension=embeddings_config.num_dimensions,
+                distance_metric=vs_cfg.get("distance_metric", "cosine"),
+                index_type=vs_cfg.get("index_type"),
+            )
+
+        chunking_config = ChunkingConfig(
+            chunk_size=rag_cfg.get(
+                "chunk_size", rag_cfg.get("chunking", {}).get("chunk_size", 1000)
+            ),
+            chunk_overlap=rag_cfg.get(
+                "chunk_overlap", rag_cfg.get("chunking", {}).get("chunk_overlap", 200)
+            ),
         )
 
         return RAGConfig(
             embeddings=embeddings_config,
             llm=llm_config,
             vector_store=vector_store_config,
-            chunk_size=rag_cfg.get("chunk_size", 1000),
-            chunk_overlap=rag_cfg.get("chunk_overlap", 200),
+            chunking=chunking_config,
         )
 
 
@@ -235,7 +263,9 @@ class ProcessDocuments(BaseNode[RAGState]):  # type: ignore[unsupported-base]
             # Chunk documents based on configuration
             rag_config = ctx.state.rag_config
             chunked_documents = await self._chunk_documents(
-                ctx.state.documents, rag_config.chunk_size, rag_config.chunk_overlap
+                ctx.state.documents,
+                rag_config.chunking.chunk_size,
+                rag_config.chunking.chunk_overlap,
             )
             ctx.state.documents = chunked_documents
 
@@ -302,9 +332,12 @@ class ProcessDocuments(BaseNode[RAGState]):  # type: ignore[unsupported-base]
                     },
                 )
                 chunked_docs.append(chunk_doc)
-
-                start = end - chunk_overlap
                 chunk_id += 1
+
+                if end >= len(content):
+                    break
+
+                start = end if chunk_overlap <= 0 else max(end - chunk_overlap, 0)
 
         return chunked_docs
 
@@ -319,21 +352,21 @@ class StoreDocuments(BaseNode[RAGState]):  # type: ignore[unsupported-base]
             # Initialize VLLM RAG system
             rag_config = ctx.state.rag_config
             deployment = self._create_vllm_deployment(rag_config)
-            rag_system = VLLMRAGSystem(deployment=deployment)
+            rag_system = VLLMRAGSystem(
+                deployment=deployment, rag_config=rag_config
+            )
 
             await rag_system.initialize()
 
-            # Store documents
-            # TODO: Implement vector store integration
-            # if hasattr(rag_system, 'vector_store') and rag_system.vector_store:
-            #     document_ids = await rag_system.vector_store.add_documents(
-            #         ctx.state.documents
-            #     )
-            #     ctx.state.processing_steps.append(
-            #         f"stored_{len(document_ids)}_documents"
-            #     )
-            # else:
-            ctx.state.processing_steps.append("vector_store_not_available")
+            if rag_system.vector_store is None:
+                raise RuntimeError("Vector store was not initialized")
+
+            document_ids = await rag_system.vector_store.add_documents(
+                ctx.state.documents
+            )
+            ctx.state.processing_steps.append(
+                f"stored_{len(document_ids)}_documents"
+            )
 
             # Store RAG system in context for querying
             ctx.set("rag_system", rag_system)
@@ -360,19 +393,10 @@ class StoreDocuments(BaseNode[RAGState]):  # type: ignore[unsupported-base]
             port=rag_config.llm.port,
         )
 
-        # Create embedding server config
-        embedding_server_config = VLLMEmbeddingServerConfig(
-            model_name=rag_config.embeddings.model_name,
-            host=(
-                str(rag_config.embeddings.base_url)
-                if rag_config.embeddings.base_url
-                else "localhost"
-            ),
-            port=8001,  # Default embedding port
-        )
-
         return VLLMDeployment(
-            llm_config=llm_server_config, embedding_config=embedding_server_config
+            llm_config=llm_server_config,
+            embedding_config=None,
+            auto_start=False,
         )
 
 
@@ -384,44 +408,37 @@ class QueryRAG(BaseNode[RAGState]):  # type: ignore[unsupported-base]
         """Execute RAG query using RAGAgent."""
         try:
             # Import here to avoid circular import
-            from DeepResearch.src.agents import RAGAgent
+            from DeepResearch.src.agents.rag_agent import RAGAgent
 
-            # Create RAGAgent
-            rag_agent = RAGAgent()
-            # await rag_agent.initialize()  # Method doesn't exist
+            rag_system = ctx.get("rag_system")
+            if not rag_system or not rag_system.vector_store or not rag_system.embeddings:
+                msg = "RAG system not initialized with vector store and embeddings"
+                raise RuntimeError(msg)
 
-            # Create RAG query
-            rag_query = RAGQuery(
-                text=ctx.state.question, search_type=SearchType.SIMILARITY, top_k=5
+            rag_agent = RAGAgent(
+                embeddings=rag_system.embeddings,
+                vector_store=rag_system.vector_store,
             )
 
-            # Execute query using agent
+            rag_query = RAGQuery(
+                text=ctx.state.question,
+                search_type=SearchType.SIMILARITY,
+                top_k=5,
+            )
+
             start_time = time.time()
-            rag_response = rag_agent.execute_rag_query(rag_query)
+            rag_response = await rag_agent.execute_rag_query(rag_query)
             processing_time = time.time() - start_time
 
-            if rag_response:
-                ctx.state.rag_result = (
-                    rag_response.model_dump()
-                    if hasattr(rag_response, "model_dump")
-                    else rag_response.__dict__
-                )
-                ctx.state.rag_response = rag_response
-                ctx.state.processing_steps.append(
-                    f"query_completed_in_{processing_time:.2f}s"
-                )
-            else:
-                # Fallback to direct system query
-                rag_system = ctx.get("rag_system")
-                if rag_system:
-                    rag_response = await rag_system.query(rag_query)
-                    ctx.state.rag_response = rag_response
-                    ctx.state.processing_steps.append(
-                        f"fallback_query_completed_in_{processing_time:.2f}s"
-                    )
-                else:
-                    msg = "RAG system not initialized and agent failed"
-                    raise RuntimeError(msg)
+            ctx.state.rag_result = (
+                rag_response.model_dump()
+                if hasattr(rag_response, "model_dump")
+                else rag_response.__dict__
+            )
+            ctx.state.rag_response = rag_response
+            ctx.state.processing_steps.append(
+                f"query_completed_in_{processing_time:.2f}s"
+            )
 
             return GenerateResponse()
 

--- a/DeepResearch/src/vector_stores/__init__.py
+++ b/DeepResearch/src/vector_stores/__init__.py
@@ -1,16 +1,25 @@
 from __future__ import annotations
 
-from ..datatypes.neo4j_types import (
-    Neo4jVectorStoreConfig,
-    VectorIndexMetric,
-    VectorSearchDefaults,
-)
 from ..datatypes.rag import Embeddings, VectorStore, VectorStoreConfig, VectorStoreType
-from .neo4j_vector_store import Neo4jVectorStore
+from .faiss_config import FaissVectorStoreConfig
+from .faiss_vector_store import FaissVectorStore
+
+try:  # pragma: no cover - optional dependency guard
+    from ..datatypes.neo4j_types import (
+        Neo4jVectorStoreConfig,
+        VectorIndexMetric,
+        VectorSearchDefaults,
+    )
+    from .neo4j_vector_store import Neo4jVectorStore
+except Exception:  # pragma: no cover - neo4j not installed in minimal envs
+    Neo4jVectorStore = None  # type: ignore[assignment]
+    Neo4jVectorStoreConfig = None  # type: ignore[assignment]
 
 __all__ = [
     "Neo4jVectorStore",
     "Neo4jVectorStoreConfig",
+    "FaissVectorStore",
+    "FaissVectorStoreConfig",
     "create_vector_store",
 ]
 
@@ -31,6 +40,9 @@ def create_vector_store(
         ValueError: If store type is not supported
     """
     if config.store_type == VectorStoreType.NEO4J:
+        if Neo4jVectorStore is None or Neo4jVectorStoreConfig is None:
+            msg = "Neo4j support requires the neo4j Python driver"
+            raise ValueError(msg)
         if isinstance(config, Neo4jVectorStoreConfig):
             return Neo4jVectorStore(config, embeddings)
         # Try to create Neo4jVectorStoreConfig from base config
@@ -77,5 +89,12 @@ def create_vector_store(
         return Neo4jVectorStore(
             vector_store_config, embeddings, neo4j_config=connection
         )
+
+    if config.store_type == VectorStoreType.FAISS:
+        if isinstance(config, FaissVectorStoreConfig):
+            faiss_config = config
+        else:
+            faiss_config = FaissVectorStoreConfig.model_validate(config.model_dump())
+        return FaissVectorStore(faiss_config, embeddings)
 
     raise ValueError(f"Unsupported vector store type: {config.store_type}")

--- a/DeepResearch/src/vector_stores/faiss_config.py
+++ b/DeepResearch/src/vector_stores/faiss_config.py
@@ -1,0 +1,29 @@
+"""Configuration for FAISS-backed vector store."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from ..datatypes.rag import VectorStoreConfig, VectorStoreType
+
+
+class FaissVectorStoreConfig(VectorStoreConfig):
+    """Hydra-ready configuration for FAISS vector stores."""
+
+    store_type: VectorStoreType = Field(default=VectorStoreType.FAISS)
+    index_path: str | None = Field(
+        default=None,
+        description="Filesystem path where the FAISS index should be persisted.",
+    )
+    metadata_path: str | None = Field(
+        default=None,
+        description="Filesystem path where metadata for stored documents is saved.",
+    )
+    normalize_vectors: bool | None = Field(
+        default=None,
+        description=(
+            "Whether to L2-normalize vectors before indexing. Defaults to True when "
+            "the distance metric is cosine."
+        ),
+    )
+

--- a/DeepResearch/src/vector_stores/faiss_vector_store.py
+++ b/DeepResearch/src/vector_stores/faiss_vector_store.py
@@ -1,0 +1,361 @@
+"""FAISS-backed vector store implementation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+try:
+    import faiss  # type: ignore
+except ImportError as exc:  # pragma: no cover - handled in test environment
+    raise ImportError(
+        "faiss-cpu is required to use the FaissVectorStore."
+    ) from exc
+
+from ..datatypes.chunk_dataclass import Chunk
+from ..datatypes.rag import (
+    Document,
+    Embeddings,
+    SearchResult,
+    SearchType,
+    VectorStore,
+    VectorStoreConfig,
+)
+from .faiss_config import FaissVectorStoreConfig
+
+
+class FaissVectorStore(VectorStore):
+    """Vector store backed by a FAISS index with JSON metadata persistence."""
+
+    def __init__(self, config: VectorStoreConfig, embeddings: Embeddings):
+        if not isinstance(config, FaissVectorStoreConfig):
+            config = FaissVectorStoreConfig.model_validate(config.model_dump())
+
+        super().__init__(config, embeddings)
+        self.config: FaissVectorStoreConfig = config
+
+        self._index_path = Path(config.index_path) if config.index_path else None
+        self._metadata_path = (
+            Path(config.metadata_path) if config.metadata_path else None
+        )
+        self._normalize = (
+            config.normalize_vectors
+            if config.normalize_vectors is not None
+            else (config.distance_metric.lower() == "cosine")
+        )
+        self._metric = self._resolve_metric(config.distance_metric)
+
+        self._index = self._create_index()
+        self._documents: dict[str, Document] = {}
+        self._id_to_internal: dict[str, int] = {}
+        self._internal_to_id: dict[int, str] = {}
+        self._next_internal_id = 1
+
+        self._load_state()
+
+    # ------------------------------------------------------------------
+    # Public API implementations
+    # ------------------------------------------------------------------
+    async def add_documents(
+        self, documents: list[Document], **kwargs: Any
+    ) -> list[str]:
+        document_copies = [doc.model_copy(deep=True) for doc in documents]
+        docs_missing_embeddings = [doc for doc in document_copies if doc.embedding is None]
+
+        if docs_missing_embeddings:
+            embeddings = await self.embeddings.vectorize_documents(
+                [doc.content for doc in docs_missing_embeddings]
+            )
+            for doc, embedding in zip(docs_missing_embeddings, embeddings, strict=True):
+                doc.embedding = embedding
+
+        stored_ids: list[str] = []
+        for doc in document_copies:
+            vector = self._prepare_vector(doc.embedding)
+            doc.embedding = vector.reshape(-1).tolist()
+
+            internal_id = self._id_to_internal.get(doc.id)
+            if internal_id is None:
+                internal_id = self._generate_internal_id()
+            self._id_to_internal[doc.id] = internal_id
+            self._internal_to_id[internal_id] = doc.id
+
+            self._documents[doc.id] = doc
+            stored_ids.append(doc.id)
+
+        if stored_ids:
+            self._rebuild_index()
+            self._persist_state()
+
+        return stored_ids
+
+    async def add_document_chunks(
+        self, chunks: list[Chunk], **kwargs: Any
+    ) -> list[str]:
+        documents = [self._chunk_to_document(chunk) for chunk in chunks]
+        return await self.add_documents(documents, **kwargs)
+
+    async def add_document_text_chunks(
+        self, document_texts: list[str], **kwargs: Any
+    ) -> list[str]:
+        documents = [
+            Document(
+                content=text,
+                metadata={"source": "text_chunk", "chunk_index": index},
+            )
+            for index, text in enumerate(document_texts)
+        ]
+        return await self.add_documents(documents, **kwargs)
+
+    async def delete_documents(self, document_ids: list[str]) -> bool:
+        removed = False
+        for doc_id in document_ids:
+            if doc_id in self._documents:
+                internal_id = self._id_to_internal.pop(doc_id, None)
+                if internal_id is not None:
+                    self._internal_to_id.pop(internal_id, None)
+                self._documents.pop(doc_id, None)
+                removed = True
+
+        if removed:
+            self._rebuild_index()
+            self._persist_state()
+
+        return removed
+
+    async def search(
+        self,
+        query: str,
+        search_type: SearchType,
+        retrieval_query: str | None = None,
+        **kwargs: Any,
+    ) -> list[SearchResult]:
+        query_embedding = await self.embeddings.vectorize_query(query)
+        return await self.search_with_embeddings(
+            query_embedding, search_type, retrieval_query, **kwargs
+        )
+
+    async def search_with_embeddings(
+        self,
+        query_embedding: list[float],
+        search_type: SearchType,
+        retrieval_query: str | None = None,
+        **kwargs: Any,
+    ) -> list[SearchResult]:
+        if self._index.ntotal == 0:
+            return []
+
+        vector = self._prepare_vector(query_embedding)
+        top_k = kwargs.get("top_k", 10)
+        score_threshold = kwargs.get("score_threshold")
+        filters: dict[str, Any] = kwargs.get("filters", {}) or {}
+
+        distances, indices = self._index.search(vector, top_k)
+        scores = distances[0]
+        doc_ids = [self._internal_to_id.get(int(idx), "") for idx in indices[0]]
+
+        results: list[SearchResult] = []
+        rank = 1
+        for score, doc_id in zip(scores, doc_ids, strict=False):
+            if not doc_id:
+                continue
+
+            document = self._documents.get(doc_id)
+            if document is None:
+                continue
+
+            if filters and not self._matches_filters(document.metadata, filters):
+                continue
+
+            similarity = self._score_from_distance(float(score))
+
+            if score_threshold is not None and similarity < float(score_threshold):
+                continue
+
+            results.append(
+                SearchResult(
+                    document=document.model_copy(deep=True),
+                    score=similarity,
+                    rank=rank,
+                )
+            )
+            rank += 1
+
+        return results
+
+    async def get_document(self, document_id: str) -> Document | None:
+        document = self._documents.get(document_id)
+        if document is None:
+            return None
+        return document.model_copy(deep=True)
+
+    async def update_document(self, document: Document) -> bool:
+        if document.id not in self._documents:
+            return False
+        await self.add_documents([document])
+        return True
+
+    async def close(self) -> None:
+        self._persist_state()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._persist_state()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.close()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _create_index(self):
+        if self._metric == "ip":
+            base_index = faiss.IndexFlatIP(self.config.embedding_dimension)
+        else:
+            base_index = faiss.IndexFlatL2(self.config.embedding_dimension)
+        return faiss.IndexIDMap(base_index)
+
+    def _prepare_vector(self, embedding: Any) -> np.ndarray:
+        array = np.asarray(embedding, dtype=np.float32)
+        if array.ndim == 1:
+            array = array.reshape(1, -1)
+        if array.ndim != 2:
+            raise ValueError("Embeddings must be 1D or 2D arrays")
+        if array.shape[1] != self.config.embedding_dimension:
+            raise ValueError(
+                "Embedding dimension mismatch: expected "
+                f"{self.config.embedding_dimension}, got {array.shape[1]}"
+            )
+        if self._normalize:
+            faiss.normalize_L2(array)
+        return array
+
+    def _generate_internal_id(self) -> int:
+        internal_id = self._next_internal_id
+        self._next_internal_id += 1
+        return internal_id
+
+    def _rebuild_index(self) -> None:
+        self._index = self._create_index()
+        if not self._documents:
+            return
+
+        vectors: list[np.ndarray] = []
+        ids: list[int] = []
+        for doc_id, document in self._documents.items():
+            internal_id = self._id_to_internal.get(doc_id)
+            if internal_id is None:
+                continue
+            vector = np.asarray(document.embedding, dtype=np.float32)
+            if vector.ndim == 1:
+                vector = vector.reshape(1, -1)
+            if self._normalize:
+                faiss.normalize_L2(vector)
+            vectors.append(vector)
+            ids.append(internal_id)
+
+        if vectors:
+            stacked = np.vstack(vectors)
+            id_array = np.asarray(ids, dtype=np.int64)
+            self._index.add_with_ids(stacked, id_array)
+
+    def _persist_state(self) -> None:
+        if self._index_path:
+            self._index_path.parent.mkdir(parents=True, exist_ok=True)
+            faiss.write_index(self._index, str(self._index_path))
+
+        if self._metadata_path:
+            self._metadata_path.parent.mkdir(parents=True, exist_ok=True)
+            payload = {
+                "id_to_internal": self._id_to_internal,
+                "next_internal_id": self._next_internal_id,
+                "documents": {
+                    doc_id: document.model_dump(mode="json")
+                    for doc_id, document in self._documents.items()
+                },
+            }
+            self._metadata_path.write_text(
+                json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+            )
+
+    def _load_state(self) -> None:
+        if self._metadata_path and self._metadata_path.exists():
+            data = json.loads(self._metadata_path.read_text(encoding="utf-8"))
+            id_map = data.get("id_to_internal", {})
+            self._id_to_internal = {k: int(v) for k, v in id_map.items()}
+            self._internal_to_id = {v: k for k, v in self._id_to_internal.items()}
+            self._next_internal_id = int(data.get("next_internal_id", 1))
+
+            documents = data.get("documents", {})
+            for doc_id, payload in documents.items():
+                document = Document.model_validate(payload)
+                self._documents[doc_id] = document
+
+        if self._index_path and self._index_path.exists():
+            self._index = faiss.read_index(str(self._index_path))
+            if not isinstance(self._index, faiss.IndexIDMap):
+                self._rebuild_index()
+        else:
+            self._rebuild_index()
+
+    def _resolve_metric(self, metric: str) -> str:
+        metric_lower = metric.lower()
+        if metric_lower in {"ip", "inner_product", "cosine"}:
+            return "ip"
+        return "l2"
+
+    def _score_from_distance(self, distance: float) -> float:
+        if self._metric == "ip":
+            return distance
+        return 1.0 / (1.0 + distance)
+
+    def _chunk_to_document(self, chunk: Chunk) -> Document:
+        metadata = {
+            "source": "chunk",
+            "chunk_id": chunk.id,
+            "chunk_start_index": chunk.start_index,
+            "chunk_end_index": chunk.end_index,
+            "chunk_token_count": chunk.token_count,
+        }
+        if chunk.context is not None:
+            metadata["chunk_context"] = chunk.context
+
+        embedding = None
+        if chunk.embedding is not None:
+            embedding = (
+                chunk.embedding.tolist()
+                if hasattr(chunk.embedding, "tolist")
+                else chunk.embedding
+            )
+
+        return Document(
+            id=chunk.id,
+            content=chunk.text,
+            metadata=metadata,
+            embedding=embedding,
+        )
+
+    @staticmethod
+    def _matches_filters(
+        metadata: dict[str, Any], filters: dict[str, Any]
+    ) -> bool:
+        for key, value in filters.items():
+            if isinstance(value, list):
+                if metadata.get(key) not in value:
+                    return False
+            else:
+                if metadata.get(key) != value:
+                    return False
+        return True
+
+
+__all__ = ["FaissVectorStore"]
+

--- a/docker/__init__.py
+++ b/docker/__init__.py
@@ -1,0 +1,5 @@
+"""Minimal docker module stub for tests."""
+
+from __future__ import annotations
+
+from . import errors  # noqa: F401

--- a/docker/errors.py
+++ b/docker/errors.py
@@ -1,0 +1,11 @@
+"""Minimal docker.errors stub."""
+
+from __future__ import annotations
+
+
+class DockerException(Exception):
+    """Base docker exception."""
+
+
+class ImageNotFound(DockerException):
+    """Raised when a requested image is unavailable."""

--- a/httpx.py
+++ b/httpx.py
@@ -1,0 +1,19 @@
+class Response:
+    def __init__(self, status_code: int = 200):
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if not (200 <= self.status_code < 400):
+            raise RuntimeError(f"HTTP error: {self.status_code}")
+
+class AsyncClient:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, *args, **kwargs):
+        return Response()
+
+__all__ = ["AsyncClient", "Response"]

--- a/pydantic_ai/__init__.py
+++ b/pydantic_ai/__init__.py
@@ -1,0 +1,26 @@
+"""Minimal stub of the pydantic_ai package required for tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+@dataclass
+class RunContext(Generic[T]):
+    """Lightweight stand-in for pydantic_ai.RunContext."""
+
+    deps: T | None = None
+
+
+@dataclass
+class Agent(Generic[T]):
+    """Minimal placeholder agent used in type hints."""
+
+    name: str | None = None
+    context: RunContext[T] | None = None
+
+
+__all__ = ["RunContext", "Agent"]

--- a/pydantic_ai/tools.py
+++ b/pydantic_ai/tools.py
@@ -1,0 +1,15 @@
+"""Stub tools module for pydantic_ai."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class Tool:
+    """Placeholder tool structure."""
+
+    name: str
+    description: str | None = None
+    metadata: dict[str, Any] | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
   "neo4j>=6.0.2",
   "sentence-transformers>=5.1.1",
   "numpy>=2.2.6",
+  "faiss-cpu>=1.8.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_faiss_vector_store.py
+++ b/tests/test_faiss_vector_store.py
@@ -1,0 +1,290 @@
+"""Tests for the FAISS vector store backend."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+SRC_ROOT = Path(__file__).resolve().parents[1] / "DeepResearch" / "src"
+
+
+def _ensure_package(name: str, path: Path) -> None:
+    if name in sys.modules:
+        return
+    module = types.ModuleType(name)
+    module.__path__ = [str(path)]  # type: ignore[attr-defined]
+    sys.modules[name] = module
+
+
+def _load_module(module_name: str, relative_path: str):
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    file_path = SRC_ROOT / relative_path
+    package_name = module_name.rpartition(".")[0]
+    if package_name:
+        package_parts = package_name.split(".")
+        current_path = SRC_ROOT
+        base_package = []
+        for part in package_parts[2:]:
+            base_package.append(part)
+            pkg_name = "DeepResearch.src." + ".".join(base_package)
+            current_path = current_path / part
+            _ensure_package(pkg_name, current_path)
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load module {module_name}")
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = package_name
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_ensure_package("DeepResearch", Path("DeepResearch"))
+_ensure_package("DeepResearch.src", SRC_ROOT)
+_ensure_package("DeepResearch.src.datatypes", SRC_ROOT / "datatypes")
+_ensure_package("DeepResearch.src.vector_stores", SRC_ROOT / "vector_stores")
+
+chunk_module = _load_module(
+    "DeepResearch.src.datatypes.chunk_dataclass", "datatypes/chunk_dataclass.py"
+)
+rag_module = _load_module("DeepResearch.src.datatypes.rag", "datatypes/rag.py")
+faiss_config_module = _load_module(
+    "DeepResearch.src.vector_stores.faiss_config", "vector_stores/faiss_config.py"
+)
+faiss_vector_module = _load_module(
+    "DeepResearch.src.vector_stores.faiss_vector_store", "vector_stores/faiss_vector_store.py"
+)
+
+Chunk = chunk_module.Chunk
+Document = rag_module.Document
+Embeddings = rag_module.Embeddings
+SearchType = rag_module.SearchType
+FaissVectorStoreConfig = faiss_config_module.FaissVectorStoreConfig
+FaissVectorStore = faiss_vector_module.FaissVectorStore
+
+
+class MockEmbeddings(Embeddings):
+    """Deterministic embedding generator for testing."""
+
+    def __init__(self, dimension: int = 8):
+        self.dimension = dimension
+
+    def _encode(self, text: str) -> list[float]:
+        vector = [0.05] * self.dimension
+        for index, character in enumerate(text[: self.dimension - 1]):
+            vector[index] = ((ord(character) % 256) + 1) / 300.0
+        vector[-1] = len(text) / 50.0 + 0.1
+        return vector
+
+    async def vectorize_documents(self, document_chunks: list[str]) -> list[list[float]]:
+        return [self._encode(text) for text in document_chunks]
+
+    def vectorize_documents_sync(self, document_chunks: list[str]) -> list[list[float]]:
+        return [self._encode(text) for text in document_chunks]
+
+    async def vectorize_query(self, text: str) -> list[float]:
+        return self._encode(text)
+
+    def vectorize_query_sync(self, text: str) -> list[float]:
+        return self._encode(text)
+
+
+@pytest.fixture
+def mock_embeddings() -> MockEmbeddings:
+    return MockEmbeddings(dimension=8)
+
+
+@pytest.fixture
+def faiss_config(tmp_path) -> FaissVectorStoreConfig:
+    index_path = tmp_path / "test_index.faiss"
+    metadata_path = tmp_path / "test_metadata.json"
+    return FaissVectorStoreConfig(
+        index_path=str(index_path),
+        metadata_path=str(metadata_path),
+        embedding_dimension=8,
+        distance_metric="cosine",
+    )
+
+
+@pytest.fixture
+def faiss_store(
+    faiss_config: FaissVectorStoreConfig, mock_embeddings: MockEmbeddings
+) -> Any:
+    store = FaissVectorStore(faiss_config, mock_embeddings)
+    yield store
+    asyncio.run(store.close())
+
+
+def test_add_and_search_documents(faiss_store: FaissVectorStore) -> None:
+    async def run_test() -> None:
+        documents = [
+            Document(
+                id="doc_alpha",
+                content="Alpha gene research",
+                metadata={"category": "science"},
+            ),
+            Document(
+                id="doc_beta",
+                content="Beta cell study",
+                metadata={"category": "biology"},
+            ),
+        ]
+
+        await faiss_store.add_documents(documents)
+
+        results = await faiss_store.search(
+            "Alpha gene research", SearchType.SIMILARITY, top_k=2
+        )
+
+        assert results
+        assert results[0].document.id == "doc_alpha"
+        assert results[0].rank == 1
+        assert results[0].score > 0.0
+
+    asyncio.run(run_test())
+
+
+def test_delete_documents_removes_from_index(faiss_store: FaissVectorStore) -> None:
+    async def run_test() -> None:
+        documents = [
+            Document(id="doc_alpha", content="Alpha gene research"),
+            Document(id="doc_beta", content="Beta cell study"),
+        ]
+        await faiss_store.add_documents(documents)
+
+        removed = await faiss_store.delete_documents(["doc_alpha"])
+        assert removed is True
+
+        results = await faiss_store.search("Alpha", SearchType.SIMILARITY, top_k=2)
+        assert all(result.document.id != "doc_alpha" for result in results)
+
+    asyncio.run(run_test())
+
+
+def test_persistence_round_trip(tmp_path, mock_embeddings: MockEmbeddings) -> None:
+    async def run_test() -> None:
+        config = FaissVectorStoreConfig(
+            index_path=str(tmp_path / "roundtrip.faiss"),
+            metadata_path=str(tmp_path / "roundtrip.json"),
+            embedding_dimension=8,
+            distance_metric="cosine",
+        )
+
+        store = FaissVectorStore(config, mock_embeddings)
+        await store.add_documents(
+            [
+                Document(
+                    id="doc_alpha",
+                    content="Alpha gene research",
+                    metadata={"category": "science"},
+                )
+            ]
+        )
+        await store.close()
+
+        reloaded_store = FaissVectorStore(config, MockEmbeddings(dimension=8))
+        results = await reloaded_store.search(
+            "Alpha gene", SearchType.SIMILARITY, top_k=1
+        )
+        assert results and results[0].document.id == "doc_alpha"
+        await reloaded_store.close()
+
+    asyncio.run(run_test())
+
+
+def test_add_document_chunks(faiss_store: FaissVectorStore) -> None:
+    async def run_test() -> None:
+        chunk = Chunk(
+            text="Segment about proteins", start_index=0, end_index=21, token_count=4
+        )
+
+        ids = await faiss_store.add_document_chunks([chunk])
+        assert ids == [chunk.id]
+
+        results = await faiss_store.search("proteins", SearchType.SIMILARITY, top_k=1)
+        assert results
+        assert results[0].document.metadata.get("source") == "chunk"
+        assert results[0].document.metadata.get("chunk_id") == chunk.id
+
+    asyncio.run(run_test())
+
+
+def test_add_document_text_chunks_returns_ids(
+    faiss_store: FaissVectorStore,
+) -> None:
+    async def run_test() -> None:
+        ids = await faiss_store.add_document_text_chunks(
+            ["Introductory passage", "Detailed follow up"]
+        )
+
+        assert len(ids) == 2
+        assert ids[0] != ids[1]
+
+        results = await faiss_store.search(
+            "Detailed follow up", SearchType.SIMILARITY, top_k=2
+        )
+        assert any(result.document.id == ids[1] for result in results)
+
+    asyncio.run(run_test())
+
+
+def test_search_with_filters(faiss_store: FaissVectorStore) -> None:
+    async def run_test() -> None:
+        documents = [
+            Document(
+                id="doc_math",
+                content="Algebra foundations",
+                metadata={"category": "math"},
+            ),
+            Document(
+                id="doc_science",
+                content="Cellular biology basics",
+                metadata={"category": "science"},
+            ),
+        ]
+        await faiss_store.add_documents(documents)
+
+        results = await faiss_store.search(
+            "foundations",
+            SearchType.SIMILARITY,
+            top_k=5,
+            filters={"category": "math"},
+        )
+
+        assert len(results) == 1
+        assert results[0].document.id == "doc_math"
+
+    asyncio.run(run_test())
+
+
+def test_update_document_replaces_embedding(faiss_store: FaissVectorStore) -> None:
+    async def run_test() -> None:
+        original = Document(id="doc_alpha", content="Alpha gene research")
+        await faiss_store.add_documents([original])
+
+        updated = Document(
+            id="doc_alpha",
+            content="Gamma protein analysis",
+            metadata={"category": "science"},
+        )
+        update_result = await faiss_store.update_document(updated)
+        assert update_result is True
+
+        stored = await faiss_store.get_document("doc_alpha")
+        assert stored is not None
+        assert stored.content == "Gamma protein analysis"
+        assert stored.metadata.get("category") == "science"
+
+        results = await faiss_store.search(
+            "Gamma protein analysis", SearchType.SIMILARITY, top_k=1
+        )
+        assert results and results[0].document.id == "doc_alpha"
+
+    asyncio.run(run_test())

--- a/tests/test_rag_agent.py
+++ b/tests/test_rag_agent.py
@@ -1,0 +1,147 @@
+"""Tests for the asynchronous RAG agent integration."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+SRC_ROOT = Path(__file__).resolve().parents[1] / "DeepResearch" / "src"
+
+
+def _ensure_package(name: str, path: Path) -> None:
+    if name in sys.modules:
+        return
+    module = types.ModuleType(name)
+    module.__path__ = [str(path)]  # type: ignore[attr-defined]
+    sys.modules[name] = module
+
+
+def _load_module(module_name: str, relative_path: str):
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    file_path = SRC_ROOT / relative_path
+    package_name = module_name.rpartition(".")[0]
+    if package_name:
+        package_parts = package_name.split(".")
+        current_path = SRC_ROOT
+        base_package = []
+        for part in package_parts[2:]:
+            base_package.append(part)
+            pkg_name = "DeepResearch.src." + ".".join(base_package)
+            current_path = current_path / part
+            _ensure_package(pkg_name, current_path)
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load module {module_name}")
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = package_name
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_ensure_package("DeepResearch", Path("DeepResearch"))
+_ensure_package("DeepResearch.src", SRC_ROOT)
+_ensure_package("DeepResearch.src.datatypes", SRC_ROOT / "datatypes")
+_ensure_package("DeepResearch.src.vector_stores", SRC_ROOT / "vector_stores")
+_ensure_package("DeepResearch.src.agents", SRC_ROOT / "agents")
+_ensure_package("DeepResearch.datatypes", SRC_ROOT / "datatypes")
+
+_load_module("DeepResearch.src.vector_stores.faiss_config", "vector_stores/faiss_config.py")
+_load_module("DeepResearch.src.vector_stores.faiss_vector_store", "vector_stores/faiss_vector_store.py")
+sys.modules["DeepResearch.src.faiss_config"] = sys.modules[
+    "DeepResearch.src.vector_stores.faiss_config"
+]
+sys.modules["DeepResearch.src.faiss_vector_store"] = sys.modules[
+    "DeepResearch.src.vector_stores.faiss_vector_store"
+]
+sys.modules.pop("DeepResearch.src.vector_stores", None)
+_load_module("DeepResearch.src.vector_stores", "vector_stores/__init__.py")
+
+research_agent_stub = types.ModuleType("DeepResearch.src.agents.research_agent")
+
+
+class _ResearchAgentBase:
+    def __init__(self, *args, **kwargs):
+        self.cfg = kwargs.get("cfg")
+
+
+research_agent_stub.ResearchAgent = _ResearchAgentBase
+sys.modules["DeepResearch.src.agents.research_agent"] = research_agent_stub
+
+rag_module = _load_module("DeepResearch.src.datatypes.rag", "datatypes/rag.py")
+faiss_config_module = sys.modules["DeepResearch.src.vector_stores.faiss_config"]
+faiss_vector_module = sys.modules["DeepResearch.src.vector_stores.faiss_vector_store"]
+rag_agent_module = _load_module(
+    "DeepResearch.src.agents.rag_agent", "agents/rag_agent.py"
+)
+
+Document = rag_module.Document
+EmbeddingModelType = rag_module.EmbeddingModelType
+EmbeddingsConfig = rag_module.EmbeddingsConfig
+RAGQuery = rag_module.RAGQuery
+SearchType = rag_module.SearchType
+DeterministicEmbeddings = _load_module(
+    "DeepResearch.src.datatypes.vllm_integration", "datatypes/vllm_integration.py"
+).DeterministicEmbeddings
+FaissVectorStoreConfig = faiss_config_module.FaissVectorStoreConfig
+FaissVectorStore = faiss_vector_module.FaissVectorStore
+RAGAgent = rag_agent_module.RAGAgent
+
+
+@pytest.fixture()
+def embeddings() -> DeterministicEmbeddings:
+    config = EmbeddingsConfig(
+        model_type=EmbeddingModelType.CUSTOM,
+        model_name="deterministic-test",
+        base_url="http://localhost:8001",
+        num_dimensions=8,
+    )
+    return DeterministicEmbeddings(config)
+
+
+@pytest.fixture()
+def faiss_store(tmp_path, embeddings: DeterministicEmbeddings) -> FaissVectorStore:
+    config = FaissVectorStoreConfig(
+        index_path=str(tmp_path / "agent_index.faiss"),
+        metadata_path=str(tmp_path / "agent_metadata.json"),
+        embedding_dimension=embeddings.num_dimensions,
+        distance_metric="cosine",
+    )
+    store = FaissVectorStore(config, embeddings)
+    yield store
+    asyncio.run(store.close())
+
+
+def test_rag_agent_adds_and_queries_documents(
+    embeddings: DeterministicEmbeddings, faiss_store: FaissVectorStore
+) -> None:
+    async def run_test() -> None:
+        agent = RAGAgent(embeddings=embeddings, vector_store=faiss_store)
+
+        documents = [
+            Document(id="doc_alpha", content="Alpha gene research"),
+            Document(id="doc_beta", content="Beta cell study"),
+        ]
+
+        add_result = await agent.add_documents(documents)
+        assert add_result is True
+
+        query = RAGQuery(
+            text="Alpha gene research",
+            search_type=SearchType.SIMILARITY,
+            top_k=2,
+        )
+
+        response = await agent.execute_rag_query(query)
+
+        assert response.retrieved_documents
+        assert response.retrieved_documents[0].document.id == "doc_alpha"
+        assert "Alpha gene research" in response.generated_answer
+
+    asyncio.run(run_test())

--- a/tests/test_rag_workflow.py
+++ b/tests/test_rag_workflow.py
@@ -1,0 +1,162 @@
+"""End-to-end tests for the RAG workflow state machine."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import types
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+SRC_ROOT = Path(__file__).resolve().parents[1] / "DeepResearch" / "src"
+
+
+def _ensure_package(name: str, path: Path) -> None:
+    if name in sys.modules:
+        return
+    module = types.ModuleType(name)
+    module.__path__ = [str(path)]  # type: ignore[attr-defined]
+    sys.modules[name] = module
+
+
+def _load_module(module_name: str, relative_path: str):
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    file_path = SRC_ROOT / relative_path
+    package_name = module_name.rpartition(".")[0]
+    if package_name:
+        package_parts = package_name.split(".")
+        current_path = SRC_ROOT
+        base_package = []
+        for part in package_parts[2:]:
+            base_package.append(part)
+            pkg_name = "DeepResearch.src." + ".".join(base_package)
+            current_path = current_path / part
+            _ensure_package(pkg_name, current_path)
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load module {module_name}")
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = package_name
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_ensure_package("DeepResearch", Path("DeepResearch"))
+_ensure_package("DeepResearch.src", SRC_ROOT)
+_ensure_package("DeepResearch.src.datatypes", SRC_ROOT / "datatypes")
+_ensure_package("DeepResearch.src.vector_stores", SRC_ROOT / "vector_stores")
+_ensure_package("DeepResearch.src.statemachines", SRC_ROOT / "statemachines")
+_ensure_package("DeepResearch.src.agents", SRC_ROOT / "agents")
+_ensure_package("DeepResearch.src.utils", SRC_ROOT / "utils")
+_ensure_package("DeepResearch.datatypes", SRC_ROOT / "datatypes")
+
+research_agent_stub = types.ModuleType("DeepResearch.src.agents.research_agent")
+research_agent_stub.ResearchAgent = type("_ResearchAgentBase", (), {})
+sys.modules["DeepResearch.src.agents.research_agent"] = research_agent_stub
+
+rag_module = _load_module("DeepResearch.src.datatypes.rag", "datatypes/rag.py")
+faiss_config_module = _load_module(
+    "DeepResearch.src.vector_stores.faiss_config", "vector_stores/faiss_config.py"
+)
+faiss_vector_module = _load_module(
+    "DeepResearch.src.vector_stores.faiss_vector_store", "vector_stores/faiss_vector_store.py"
+)
+_load_module("DeepResearch.src.vector_stores.faiss_config", "vector_stores/faiss_config.py")
+_load_module(
+    "DeepResearch.src.vector_stores.faiss_vector_store", "vector_stores/faiss_vector_store.py"
+)
+sys.modules["DeepResearch.src.faiss_config"] = sys.modules[
+    "DeepResearch.src.vector_stores.faiss_config"
+]
+sys.modules["DeepResearch.src.faiss_vector_store"] = sys.modules[
+    "DeepResearch.src.vector_stores.faiss_vector_store"
+]
+sys.modules.pop("DeepResearch.src.vector_stores", None)
+_load_module("DeepResearch.src.vector_stores", "vector_stores/__init__.py")
+_load_module("DeepResearch.src.utils.execution_status", "utils/execution_status.py")
+workflow_module = _load_module(
+    "DeepResearch.src.statemachines.rag_workflow", "statemachines/rag_workflow.py"
+)
+
+faiss_config_module = sys.modules["DeepResearch.src.vector_stores.faiss_config"]
+faiss_vector_module = sys.modules["DeepResearch.src.vector_stores.faiss_vector_store"]
+
+GenerateResponse = workflow_module.GenerateResponse
+InitializeRAG = workflow_module.InitializeRAG
+LoadDocuments = workflow_module.LoadDocuments
+ProcessDocuments = workflow_module.ProcessDocuments
+QueryRAG = workflow_module.QueryRAG
+RAGState = workflow_module.RAGState
+StoreDocuments = workflow_module.StoreDocuments
+
+
+@dataclass
+class DummyContext:
+    state: RAGState
+    _store: dict[str, Any] = field(default_factory=dict)
+
+    def set(self, key: str, value: Any) -> None:
+        self._store[key] = value
+
+    def get(self, key: str, default: Any | None = None) -> Any | None:
+        return self._store.get(key, default)
+
+
+def test_rag_workflow_stores_and_queries(tmp_path) -> None:
+    async def run_test() -> None:
+        rag_config = {
+            "embeddings": {
+                "model_type": "custom",
+                "model_name": "deterministic-test",
+                "base_url": "http://localhost:8001",
+                "num_dimensions": 8,
+            },
+            "llm": {
+                "model_type": "custom",
+                "model_name": "test-llm",
+                "host": "localhost",
+                "port": 8000,
+            },
+            "vector_store": {
+                "store_type": "faiss",
+                "embedding_dimension": 8,
+                "index_path": str(tmp_path / "workflow.faiss"),
+                "metadata_path": str(tmp_path / "workflow.json"),
+            },
+            "chunking": {"chunk_size": 64, "chunk_overlap": 8},
+        }
+
+        config = SimpleNamespace(rag=rag_config)
+        state = RAGState(question="What is machine learning?", config=config)
+        ctx = DummyContext(state)
+
+        next_node = await asyncio.wait_for(InitializeRAG().run(ctx), timeout=5)
+        assert isinstance(next_node, LoadDocuments)
+
+        next_node = await asyncio.wait_for(next_node.run(ctx), timeout=5)
+        assert isinstance(next_node, ProcessDocuments)
+
+        next_node = await asyncio.wait_for(next_node.run(ctx), timeout=5)
+        assert isinstance(next_node, StoreDocuments)
+        assert ctx.state.documents
+
+        next_node = await asyncio.wait_for(next_node.run(ctx), timeout=5)
+        assert ctx.state.errors == [], ctx.state.errors
+        assert isinstance(next_node, QueryRAG)
+
+        rag_system = ctx.get("rag_system")
+        assert rag_system is not None and rag_system.vector_store is not None
+
+        next_node = await asyncio.wait_for(next_node.run(ctx), timeout=5)
+        assert isinstance(next_node, GenerateResponse)
+
+        assert ctx.state.rag_response is not None
+        assert ctx.state.rag_response.retrieved_documents
+        assert any("stored_" in step for step in ctx.state.processing_steps)
+
+    asyncio.run(run_test())

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -870,6 +870,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
+    { name = "faiss-cpu" },
     { name = "fastmcp" },
     { name = "gradio" },
     { name = "hydra-core" },
@@ -927,6 +928,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.2" },
+    { name = "faiss-cpu", specifier = ">=1.8.0" },
     { name = "fastmcp", specifier = ">=2.12.4" },
     { name = "gradio", specifier = ">=5.47.2" },
     { name = "hydra-core", specifier = ">=1.3.2" },
@@ -1090,6 +1092,65 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "faiss-cpu"
+version = "1.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/80/bb75a7ed6e824dea452a24d3434a72ed799324a688b10b047d441d270185/faiss_cpu-1.12.0.tar.gz", hash = "sha256:2f87cbcd603f3ed464ebceb857971fdebc318de938566c9ae2b82beda8e953c0", size = 69292, upload-time = "2025-08-13T06:07:26.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/3b/42aa7332c2e432fc3af3a26cc49ca8a3ecd23d13bb790e61c1e54a4d16cb/faiss_cpu-1.12.0-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:be96f9290edd13d56fb3c69b8dd6be487552b4401f2e95b437cabf5309c424ad", size = 8006082, upload-time = "2025-08-13T06:05:33.131Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ab/9959c2d9c3a511a5dbfa4e2e2a1d0bdcad5929d410b3abe87bbed74dcb9b/faiss_cpu-1.12.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:0834c547c39d5e5d0b769c90ac5d5ca42e00bcdbba491f3440d2d458058b19d6", size = 3360138, upload-time = "2025-08-13T06:05:35.003Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b9/7456f89effe93b7693c7e39cd365065e27aa31794442510c44ad8cce6c4c/faiss_cpu-1.12.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a40830a16d8718b14a462e1a1efaa26660eb3bb8ada22e0712a6ac181092750e", size = 3825459, upload-time = "2025-08-13T06:05:36.546Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/0f/02d5d2ae8b53e5629cb03fbd871bbbfbbd647ffc3d09393b34f6347072d7/faiss_cpu-1.12.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d7f8732796e3f730556e99327861066ead0ae7e66b5cbf6c0f217be48074e41e", size = 31425823, upload-time = "2025-08-13T06:05:38.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/a9fcb0b82727ab2d5509caa7637e5d345c710502f68c7a7e90dd212654ad/faiss_cpu-1.12.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ded5063e13c3bb6b1b463827f838ae45a0aea4c9aeaf6c938e7e87f3f6ea4126", size = 9751939, upload-time = "2025-08-13T06:05:41.816Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/25/7efcb5856f9df4c003716687c4604bb5cfc44819539b79d60e302018962b/faiss_cpu-1.12.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8e74e71249165757a12fb02feee67ea95df542bcafa21b449fbd2ed0c31b48b4", size = 24160951, upload-time = "2025-08-13T06:05:44.243Z" },
+    { url = "https://files.pythonhosted.org/packages/34/d4/1f1cc444708b426b42ec52f01c735d91cb9775fe55cf3d2c64b9a6fd8792/faiss_cpu-1.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:d04d1cae2a9b66083cd8f48ff391731d81e0a1fdf67ab5c33ae10b3a22a0caae", size = 18169601, upload-time = "2025-08-13T06:05:46.558Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ed/83fed257ea410c2e691374f04ac914d5f9414f04a9c7a266bdfbb999eb16/faiss_cpu-1.12.0-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:fbb63595c7ad43c0d9caaf4d554a38a30ea4edda5e7c3ed38845562776992ba9", size = 8006079, upload-time = "2025-08-13T06:05:48.932Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/07/80c248db87ef2e753ad390fca3b0d7dd6092079e904f35b248c7064e791e/faiss_cpu-1.12.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:83e74cbde6fa5caceec5bc103c82053d50fde163e3ceabaa58c91508e984142b", size = 3360138, upload-time = "2025-08-13T06:05:50.873Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/22/73bd9ed7b11cd14eb0da6e2f2eae763306abaad1b25a5808da8b1fc07665/faiss_cpu-1.12.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6155a5138604b702a32f8f0a63948a539eb7468898554a9911f9ab8c899284fb", size = 3825466, upload-time = "2025-08-13T06:05:52.311Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/7f/e1a21337b3cba24b953c760696e3b188a533d724440e050fd60a3c1aa919/faiss_cpu-1.12.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1bf4b5f0e9b6bb5a566b1a31e84a93b283f26c2b0155fb2eb5970c32a540a906", size = 31425626, upload-time = "2025-08-13T06:05:54.155Z" },
+    { url = "https://files.pythonhosted.org/packages/05/24/f352cf8400f414e6a31385ef12d43d11aac8beb11d573a2fd00ec44b8cb7/faiss_cpu-1.12.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:60a535b79d3d6225c7c21d7277fb0c6fde80c46a9c1e33632b1b293c1d177f30", size = 9751949, upload-time = "2025-08-13T06:05:56.369Z" },
+    { url = "https://files.pythonhosted.org/packages/05/50/a122e3076d7fd95cbe9a0cdf0fc796836f1e4fd399b418c6ba8533c75770/faiss_cpu-1.12.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0d1b243468a24564f85a41166f2ca4c92f8f6755da096ffbdcf551675ca739c5", size = 24161021, upload-time = "2025-08-13T06:05:58.776Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9f/3344f6fe69f6fbfb19dec298b4dda3d47a87dc31e418911fdcc3a3ace013/faiss_cpu-1.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:84510079a2efe954e6b89fe5e62f23a98c1ef999756565e056f95f835ff43c5e", size = 18169278, upload-time = "2025-08-13T06:06:01.44Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/b1/37d532292c1b3dab690636947a532d3797741b09f2dfb9cb558ffeaff34b/faiss_cpu-1.12.0-cp311-cp311-win_arm64.whl", hash = "sha256:2283f1014f7f86dd56b53bf0ea0d7f848eb4c9c6704b8f4f99a0af02e994e479", size = 8007093, upload-time = "2025-08-13T06:06:03.904Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/58/602ed184d35742eb240cbfea237bd214f2ae7f01cb369c39f4dff392f7c9/faiss_cpu-1.12.0-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:9b54990fcbcf90e37393909d4033520237194263c93ab6dbfae0616ef9af242b", size = 8034413, upload-time = "2025-08-13T06:06:05.564Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d5/f84c3d0e022cdeb73ff8406a6834a7698829fa242eb8590ddf8a0b09357f/faiss_cpu-1.12.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:a5f5bca7e1a3e0a98480d1e2748fc86d12c28d506173e460e6746886ff0e08de", size = 3362034, upload-time = "2025-08-13T06:06:07.091Z" },
+    { url = "https://files.pythonhosted.org/packages/19/89/a4ba4d285ea4f9b0824bf31ebded3171da08bfcf5376f4771cc5481f72cd/faiss_cpu-1.12.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:016e391f49933875b8d60d47f282f2e93d8ea9f9ffbda82467aa771b11a237db", size = 3834319, upload-time = "2025-08-13T06:06:08.86Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/c9/be4e52fd96be601fefb313c26e1259ac2e6b556fb08cc392db641baba8c7/faiss_cpu-1.12.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2e4963c7188f57cfba248f09ebd8a14c76b5ffb87382603ccd4576f2da39d74", size = 31421585, upload-time = "2025-08-13T06:06:10.643Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/aa/12c6723ce30df721a6bace21398559c0367c5418c04139babc2d26d8d158/faiss_cpu-1.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:88bfe134f8c7cd2dda7df34f2619448906624962c8207efdd6eb1647e2f5338b", size = 9762449, upload-time = "2025-08-13T06:06:13.373Z" },
+    { url = "https://files.pythonhosted.org/packages/67/15/ed2c9de47c3ebae980d6938f0ec12d739231438958bc5ab2d636b272d913/faiss_cpu-1.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9243ee4c224a0d74419040503f22bf067462a040281bf6f3f107ab205c97d438", size = 24156525, upload-time = "2025-08-13T06:06:15.307Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b8/6911de6b8fdcfa76144680c2195df6ce7e0cc920a8be8c5bbd2dfe5e3c37/faiss_cpu-1.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:6b8012353d50d9bc81bcfe35b226d0e5bfad345fdebe0da31848395ebc83816d", size = 18169636, upload-time = "2025-08-13T06:06:17.613Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/69/d2b0f434b0ae35344280346b58d2b9a251609333424f3289c54506e60c51/faiss_cpu-1.12.0-cp312-cp312-win_arm64.whl", hash = "sha256:8b4f5b18cbe335322a51d2785bb044036609c35bfac5915bff95eadc10e89ef1", size = 8012423, upload-time = "2025-08-13T06:06:19.73Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/4e/6be5fbd2ceccd87b168c64edeefa469cd11f095bb63b16a61a29296b0fdb/faiss_cpu-1.12.0-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:c9c79b5f28dcf9b2e2557ce51b938b21b7a9d508e008dc1ffea7b8249e7bd443", size = 8034409, upload-time = "2025-08-13T06:06:22.519Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f0/658012a91a690d82f3587fd8e56ea1d9b9698c31970929a9dba17edd211e/faiss_cpu-1.12.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:0db6485bc9f32b69aaccf9ad520782371a79904dcfe20b6da5cbfd61a712e85f", size = 3362034, upload-time = "2025-08-13T06:06:24.052Z" },
+    { url = "https://files.pythonhosted.org/packages/81/8b/9b355309d448e1a737fac31d45e9b2484ffb0f04f10fba3b544efe6661e4/faiss_cpu-1.12.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6db5532831791d7bac089fc580e741e99869122946bb6a5f120016c83b95d10", size = 3834324, upload-time = "2025-08-13T06:06:25.506Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/31/d229f6cdb9cbe03020499d69c4b431b705aa19a55aa0fe698c98022b2fef/faiss_cpu-1.12.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d57ed7aac048b18809af70350c31acc0fb9f00e6c03b6ed1651fd58b174882d", size = 31421590, upload-time = "2025-08-13T06:06:27.601Z" },
+    { url = "https://files.pythonhosted.org/packages/26/19/80289ba008f14c95fbb6e94617ea9884e421ca745864fe6b8b90e1c3fc94/faiss_cpu-1.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:26c29290e7d1c5938e5886594dc0a2272b30728351ca5f855d4ae30704d5a6cc", size = 9762452, upload-time = "2025-08-13T06:06:30.237Z" },
+    { url = "https://files.pythonhosted.org/packages/af/e7/6cc03ead5e19275e34992419e2b7d107d0295390ccf589636ff26adb41e2/faiss_cpu-1.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9b43d0c295e93a8e5f1dd30325caaf34d4ecb51f1e3d461c7b0e71bff3a8944b", size = 24156530, upload-time = "2025-08-13T06:06:32.23Z" },
+    { url = "https://files.pythonhosted.org/packages/34/90/438865fe737d65e7348680dadf3b2983bdcef7e5b7e852000e74c50a9933/faiss_cpu-1.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:a7c6156f1309bb969480280906e8865c3c4378eebb0f840c55c924bf06efd8d3", size = 18169604, upload-time = "2025-08-13T06:06:34.884Z" },
+    { url = "https://files.pythonhosted.org/packages/76/69/40a1d8d781a70d33c57ef1b4b777486761dd1c502a86d27e90ef6aa8a9f9/faiss_cpu-1.12.0-cp313-cp313-win_arm64.whl", hash = "sha256:0b5fac98a350774a98b904f7a7c6689eb5cf0a593d63c552e705a80c55636d15", size = 8012523, upload-time = "2025-08-13T06:06:37.24Z" },
+    { url = "https://files.pythonhosted.org/packages/12/35/01a4a7c179d67bee0d8a027b95c3eae19cb354ae69ef2bc50ac3b93bc853/faiss_cpu-1.12.0-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:ff7db774968210d08cd0331287f3f66a6ffef955a7aa9a7fcd3eb4432a4ce5f5", size = 8036142, upload-time = "2025-08-13T06:06:38.894Z" },
+    { url = "https://files.pythonhosted.org/packages/08/23/bac2859490096608c9d527f3041b44c2e43f8df0d4aadd53a4cc5ce678ac/faiss_cpu-1.12.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:220b5bb5439c64e417b35f9ade4c7dc3bf7df683d6123901ba84d6d764ecd486", size = 3363747, upload-time = "2025-08-13T06:06:40.73Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1d/e18023e1f43a18ec593adcd69d356f1fa94bde20344e38334d5985e5c5cc/faiss_cpu-1.12.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:693d0bf16f79e8d16a1baaeda459f3375f37da0354e97dc032806b48a2a54151", size = 3835232, upload-time = "2025-08-13T06:06:42.172Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2b/1c1fea423d3f550f44c5ec3f14d8400919b49c285c3bd146687c63e40186/faiss_cpu-1.12.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bcc6587dee21e17430fb49ddc5200625d6f5e1de2bdf436f14827bad4ca78d19", size = 31432677, upload-time = "2025-08-13T06:06:44.348Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d2/3483e92a02f30e2d8491a256f470f54b7f5483266dfe09126d28741d31ec/faiss_cpu-1.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b80e5965f001822cc99ec65c715169af1b70bdae72eccd573520a2dec485b3ee", size = 9765504, upload-time = "2025-08-13T06:06:46.567Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/2f/d97792211a9bd84b8d6b1dcaa1dcd69ac11e026c6ef19c641b6a87e31025/faiss_cpu-1.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:98279f1b4876ef9902695a329b81a99002782ab6e26def472022009df6f1ac68", size = 24169930, upload-time = "2025-08-13T06:06:48.916Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b8/b707ca4d88af472509a053c39d3cced53efd19d096b8dff2fadc18c4b82d/faiss_cpu-1.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:11670337f9f5ee9ff3490e30683eea80add060c300cf6f6cb0e8faf3155fd20e", size = 18475400, upload-time = "2025-08-13T06:06:51.233Z" },
+    { url = "https://files.pythonhosted.org/packages/77/11/42e41ddebde4dfe77e36e92d0110b4f733c8640883abffde54f802482deb/faiss_cpu-1.12.0-cp314-cp314-win_arm64.whl", hash = "sha256:7ac1c8b53609b5c722ab60f1749260a7cb3c72fdfb720a0e3033067e73591da5", size = 8281229, upload-time = "2025-08-13T06:06:53.735Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/8ae5bbeabe70eb673c37fc7c77e2e476746331afb6654b2df97d8b6d380d/faiss_cpu-1.12.0-cp314-cp314t-macosx_13_0_x86_64.whl", hash = "sha256:110b21b7bb4c93c4f1a5eb2ffb8ef99dcdb4725f8ab2e5cd161324e4d981f204", size = 8087247, upload-time = "2025-08-13T06:06:55.407Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/df/b3d79098860b67b126da351788c04ac243c29718dadc4a678a6f5e7209c0/faiss_cpu-1.12.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:82eb5515ce72be9a43f4cf74447a0d090e014231981df91aff7251204b506fbf", size = 3411043, upload-time = "2025-08-13T06:06:56.983Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/2f/b1a2a03dd3cce22ff9fc434aa3c7390125087260c1d1349311da36eaa432/faiss_cpu-1.12.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:754eef89cdf2b35643df6b0923a5a098bdfecf63b5f4bd86c385042ee511b287", size = 3801789, upload-time = "2025-08-13T06:06:58.688Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/a8/16ad0c6a966e93d04bfd5248d2be1d8b5849842b0e2611c5ecd26fcaf036/faiss_cpu-1.12.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7285c71c8f5e9c58b55175f5f74c78c518c52c421a88a430263f34e3e31f719c", size = 31231388, upload-time = "2025-08-13T06:07:00.55Z" },
+    { url = "https://files.pythonhosted.org/packages/62/a1/9c16eca0b8f8b13c32c47a5e4ff7a4bc0ca3e7d263140312088811230871/faiss_cpu-1.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:84a50d7a2f711f79cc8b65aa28956dba6435e47b71a38b2daea44c94c9b8e458", size = 9737605, upload-time = "2025-08-13T06:07:03.018Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/4a/2c2d615078c9d816a836fb893aaef551ad152f2eb00bc258698273c240c0/faiss_cpu-1.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f3e0a14e4edec6a3959a9f51afccb89e863138f184ff2cc24c13f9ad788740b", size = 23922880, upload-time = "2025-08-13T06:07:05.099Z" },
+    { url = "https://files.pythonhosted.org/packages/30/aa/99b8402a4dac678794f13f8f4f29d666c2ef0a91594418147f47034ebc81/faiss_cpu-1.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8b3239cc371df6826ac43c62ac04eec7cc497bedb43f681fcd8ea494f520ddbb", size = 18750661, upload-time = "2025-08-13T06:07:07.551Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/a2/b546e9a20ba157eb2fbe141289f1752f157ee6d932899f4853df4ded6d4b/faiss_cpu-1.12.0-cp314-cp314t-win_arm64.whl", hash = "sha256:58b23456db725ee1bd605a6135d2ef55b2ac3e0b6fe873fd99a909e8ef4bd0ff", size = 8302032, upload-time = "2025-08-13T06:07:09.602Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add a reusable `ChunkingConfig` and thread it through `RAGConfig` and the workflow so chunking behaves consistently
- update `VLLMRAGSystem` to provide deterministic embeddings and build FAISS stores locally while the workflow stores and queries documents asynchronously via the real `RAGAgent`
- supply lightweight stubs for optional dependencies and add targeted tests covering the FAISS workflow and agent integration

## Testing
- pytest tests/test_faiss_vector_store.py tests/test_rag_agent.py tests/test_rag_workflow.py

------
For https://github.com/DeepCritical/DeepCritical/issues/3