### PR TITLE
feat: Integrate OpenMM into DeepCritical toolbox

### DIFF
--- a/DeepResearch/src/tools/bioinformatics/openmm_server.py
+++ b/DeepResearch/src/tools/bioinformatics/openmm_server.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from openmm import app, LangevinIntegrator, Platform # type: ignore
+from openmm.unit import kelvin, nanometer, picosecond, femtosecond # type: ignore
+from pdbfixer import PDBFixer # type: ignore
+
+from DeepResearch.src.tools.base import ExecutionResult, ToolRunner, ToolSpec
+
+
+@dataclass
+class OpenMMServer(ToolRunner):
+    spec: ToolSpec = field(
+        default_factory=lambda: ToolSpec(
+            name="openmm_server",
+            description="Clean a PDB file and run an energy minimization.",
+            inputs={
+                "pdb_file": "PATH",
+            },
+            outputs={
+                "cleaned_pdb_file": "PATH",
+                "energy": "TEXT",
+            },
+        )
+    )
+
+    def run(self, params: dict[str, str]) -> ExecutionResult:
+        """Run the OpenMM server."""
+        try:
+            pdb_file = params["pdb_file"]
+
+            # Clean PDB file
+            fixer = PDBFixer(filename=pdb_file)
+            fixer.findMissingResidues()
+            fixer.findNonstandardResidues()
+            fixer.replaceNonstandardResidues()
+            fixer.removeHeterogens(True)
+            fixer.findMissingAtoms()
+            fixer.addMissingAtoms()
+            fixer.addMissingHydrogens(7.0)
+
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".pdb", delete=False) as tmp:
+                app.PDBFile.writeFile(fixer.topology, fixer.positions, tmp)
+                cleaned_pdb_file = tmp.name
+
+            # Run energy minimization
+            pdb = app.PDBFile(cleaned_pdb_file)
+            forcefield = app.ForceField("amber14-all.xml", "amber14/tip3pfb.xml")
+
+            # Add ignoreExternalBonds=True to handle non-standard PDB files
+            system = forcefield.createSystem(
+                pdb.topology,
+                nonbondedMethod=app.NoCutoff,
+                nonbondedCutoff=1.0 * nanometer,
+                constraints=app.HBonds,
+                ignoreExternalBonds=True,
+            )
+            integrator = LangevinIntegrator(
+                300 * kelvin, 1.0 / picosecond, 2.0 * femtosecond
+            )
+            platform = Platform.getPlatformByName("CPU")
+            simulation = app.Simulation(
+                pdb.topology, system, integrator, platform
+            )
+            simulation.context.setPositions(pdb.positions)
+            simulation.minimizeEnergy()
+
+            state = simulation.context.getState(getEnergy=True)
+            energy = state.getPotentialEnergy()._value
+
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".pdb", delete=False) as tmp:
+                positions = simulation.context.getState(getPositions=True).getPositions()
+                app.PDBFile.writeFile(simulation.topology, positions, tmp)
+                minimized_pdb_file = tmp.name
+
+            return ExecutionResult(
+                success=True,
+                data={
+                    "cleaned_pdb_file": minimized_pdb_file,
+                    "energy": str(energy),
+                },
+            )
+        except Exception as e:
+            return ExecutionResult(
+                success=False,
+                error=str(e),
+            )

--- a/DeepResearch/src/tools/bioinformatics/openmm_server.py
+++ b/DeepResearch/src/tools/bioinformatics/openmm_server.py
@@ -4,9 +4,9 @@ import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from openmm import app, LangevinIntegrator, Platform # type: ignore
-from openmm.unit import kelvin, nanometer, picosecond, femtosecond # type: ignore
-from pdbfixer import PDBFixer # type: ignore
+from openmm import LangevinIntegrator, Platform, app  # type: ignore
+from openmm.unit import femtosecond, kelvin, nanometer, picosecond  # type: ignore
+from pdbfixer import PDBFixer  # type: ignore
 
 from DeepResearch.src.tools.base import ExecutionResult, ToolRunner, ToolSpec
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,10 @@ dependencies = [
   "fastmcp>=2.12.4",
   "neo4j>=6.0.2",
   "sentence-transformers>=5.1.1",
-  "numpy>=2.2.6",
+  "numpy<2",
   "faiss-cpu>=1.7.4",
+  "openmm",
+  "black-pdbfixer",
 ]
 
 [project.optional-dependencies]

--- a/tests/tools/bioinformatics/test_openmm_server.py
+++ b/tests/tools/bioinformatics/test_openmm_server.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from DeepResearch.src.tools.bioinformatics.openmm_server import OpenMMServer
+
+# Sample PDB content for testing
+PDB_CONTENT = """
+ATOM      1  N   ALA A   1      27.278  39.027  58.236  1.00  0.00           N
+ATOM      2  CA  ALA A   1      28.125  36.892  57.886  1.00  0.00           C
+ATOM      3  C   ALA A   1      27.391  37.476  56.918  1.00  0.00           C
+ATOM      4  O   ALA A   1      26.963  38.289  57.292  1.00  0.00           O
+ATOM      5  CB  ALA A   1      29.049  37.892  58.236  1.00  0.00           C
+ATOM      6  N   ALA A   2      27.878  39.527  58.736  1.00  0.00           N
+ATOM      7  CA  ALA A   2      28.625  37.392  58.386  1.00  0.00           C
+ATOM      8  C   ALA A   2      27.891  37.976  57.418  1.00  0.00           C
+ATOM      9  O   ALA A   2      27.463  38.789  57.792  1.00  0.00           O
+ATOM     10  CB  ALA A   2      29.549  38.392  58.736  1.00  0.00           C
+"""
+
+
+@pytest.fixture
+def pdb_file() -> str:
+    """Create a temporary PDB file for testing."""
+    with tempfile.NamedTemporaryFile(suffix=".pdb", delete=False) as tmp:
+        tmp.write(PDB_CONTENT.encode())
+        return tmp.name
+
+
+def test_openmm_server(pdb_file: str):
+    """Test the OpenMM server."""
+    server = OpenMMServer()
+    result = server.run({"pdb_file": pdb_file})
+
+    assert result.success
+    assert "cleaned_pdb_file" in result.data
+    assert "energy" in result.data
+
+    # Verify that the output file exists
+    cleaned_pdb_path = Path(result.data["cleaned_pdb_file"])
+    assert cleaned_pdb_path.exists()
+
+    # Verify that the energy is a float
+    energy = float(result.data["energy"])
+    assert isinstance(energy, float)


### PR DESCRIPTION
This commit integrates OpenMM into the DeepCritical toolbox by adding a new tool that can clean a PDB file and run an energy minimization.

The new tool is located in `DeepResearch/src/tools/bioinformatics/openmm_server.py` and is accompanied by a test in `tests/tools/bioinformatics/test_openmm_server.py`.

The following changes were made:
- Added `openmm` and `black-pdbfixer` to `pyproject.toml`.
- Downgraded `numpy` to `<2` to resolve a dependency conflict with `black-pdbfixer`.
- Created the `OpenMMServer` tool, which takes a PDB file, cleans it with `pdbfixer`, and runs an energy minimization with OpenMM.
- Added a test for the `OpenMMServer` tool.
- Fixed several issues that arose during testing, including missing `pdbfixer` template files, incorrect file opening modes, and an invalid test PDB file.
- Passed all pre-commit checks, including tests, linting, and type checking.