### PR TITLE
Implement end-to-end hypothesis generation and testing workflow for issue #14

### DIFF
--- a/DeepResearch/src/agents/workflow_orchestrator.py
+++ b/DeepResearch/src/agents/workflow_orchestrator.py
@@ -245,8 +245,7 @@ class PrimaryWorkflowOrchestrator:
                 hypothesis=hypothesis,
                 test_configuration=test_configuration,
                 expected_outcomes=expected_outcomes,
-                success_criteria=success_criteria
-                or {"criteria": expected_outcomes},
+                success_criteria=success_criteria or {"criteria": expected_outcomes},
             )
 
     async def execute_primary_workflow(

--- a/DeepResearch/src/agents/workflow_orchestrator.py
+++ b/DeepResearch/src/agents/workflow_orchestrator.py
@@ -237,6 +237,7 @@ class PrimaryWorkflowOrchestrator:
             hypothesis: dict[str, Any],
             test_configuration: dict[str, Any],
             expected_outcomes: list[str],
+            success_criteria: dict[str, Any] | None = None,
         ) -> HypothesisTestingEnvironment:
             """Create a hypothesis testing environment."""
             return HypothesisTestingEnvironment(
@@ -244,6 +245,8 @@ class PrimaryWorkflowOrchestrator:
                 hypothesis=hypothesis,
                 test_configuration=test_configuration,
                 expected_outcomes=expected_outcomes,
+                success_criteria=success_criteria
+                or {"criteria": expected_outcomes},
             )
 
     async def execute_primary_workflow(
@@ -460,8 +463,6 @@ class PrimaryWorkflowOrchestrator:
         self, input_data: dict[str, Any], parameters: dict[str, Any]
     ) -> dict[str, Any]:
         """Execute hypothesis generation workflow."""
-        from omegaconf import DictConfig
-
         from DeepResearch.src.statemachines.hypothesis_workflow import (
             run_hypothesis_workflow,
         )
@@ -473,33 +474,16 @@ class PrimaryWorkflowOrchestrator:
             or input_data.get("research_question")
             or ""
         )
-        cfg = DictConfig(
-            {
-                "workflow_orchestration": {"enabled": False},
-                "flows": {
-                    "hypothesis_generation": {"enabled": True},
-                    "hypothesis_testing": {"enabled": False},
-                },
-                "hypothesis": {
-                    "mode": "generate",
-                    "max_hypotheses": parameters.get("max_hypotheses", 3),
-                    "top_k": parameters.get("top_k", 3),
-                    "evidence_mode": parameters.get("evidence_mode", "search_only"),
-                    "generate_testing_plans": parameters.get(
-                        "generate_testing_plans", False
-                    ),
-                    "score_weights": parameters.get("score_weights", {}),
-                },
-            }
-        )
-        return await run_hypothesis_workflow(question, cfg, mode="generate")
+        cfg = self._build_hypothesis_config(parameters, testing_enabled=False)
+        workflow_kwargs: dict[str, Any] = {"mode": "generate"}
+        if input_data.get("existing_hypotheses") is not None:
+            workflow_kwargs["existing_hypotheses"] = input_data["existing_hypotheses"]
+        return await run_hypothesis_workflow(question, cfg, **workflow_kwargs)
 
     async def _execute_hypothesis_testing_workflow(
         self, input_data: dict[str, Any], parameters: dict[str, Any]
     ) -> dict[str, Any]:
         """Execute hypothesis testing workflow."""
-        from omegaconf import DictConfig
-
         from DeepResearch.src.statemachines.hypothesis_workflow import (
             run_hypothesis_workflow,
         )
@@ -511,26 +495,39 @@ class PrimaryWorkflowOrchestrator:
             or input_data.get("research_question")
             or ""
         )
+        cfg = self._build_hypothesis_config(parameters, testing_enabled=True)
+        workflow_kwargs: dict[str, Any] = {"mode": "testing"}
+        if input_data.get("existing_hypotheses") is not None:
+            workflow_kwargs["existing_hypotheses"] = input_data["existing_hypotheses"]
+        return await run_hypothesis_workflow(question, cfg, **workflow_kwargs)
+
+    def _build_hypothesis_config(
+        self, parameters: dict[str, Any], *, testing_enabled: bool
+    ) -> "DictConfig":
+        """Build a minimal config for delegating hypothesis workflows."""
+        from omegaconf import DictConfig
+
+        mode = "testing" if testing_enabled else "generate"
         cfg = DictConfig(
             {
                 "workflow_orchestration": {"enabled": False},
                 "flows": {
-                    "hypothesis_generation": {"enabled": False},
-                    "hypothesis_testing": {"enabled": True},
+                    "hypothesis_generation": {"enabled": not testing_enabled},
+                    "hypothesis_testing": {"enabled": testing_enabled},
                 },
                 "hypothesis": {
-                    "mode": "generate_and_plan_tests",
+                    "mode": mode,
                     "max_hypotheses": parameters.get("max_hypotheses", 3),
                     "top_k": parameters.get("top_k", 3),
                     "evidence_mode": parameters.get("evidence_mode", "search_only"),
-                    "generate_testing_plans": True,
+                    "generate_testing_plans": testing_enabled
+                    or parameters.get("generate_testing_plans", False),
                     "score_weights": parameters.get("score_weights", {}),
+                    "existing_hypotheses": parameters.get("existing_hypotheses", []),
                 },
             }
         )
-        return await run_hypothesis_workflow(
-            question, cfg, mode="generate_and_plan_tests"
-        )
+        return cfg
 
     async def _execute_reasoning_workflow(
         self, input_data: dict[str, Any], parameters: dict[str, Any]

--- a/DeepResearch/src/agents/workflow_orchestrator.py
+++ b/DeepResearch/src/agents/workflow_orchestrator.py
@@ -502,7 +502,7 @@ class PrimaryWorkflowOrchestrator:
 
     def _build_hypothesis_config(
         self, parameters: dict[str, Any], *, testing_enabled: bool
-    ) -> "DictConfig":
+    ) -> DictConfig:
         """Build a minimal config for delegating hypothesis workflows."""
         from omegaconf import DictConfig
 

--- a/DeepResearch/src/statemachines/hypothesis_workflow.py
+++ b/DeepResearch/src/statemachines/hypothesis_workflow.py
@@ -84,6 +84,7 @@ class HypothesisWorkflowState(BaseModel):
         default_factory=dict, description="Optional score weights"
     )
     config: Any | None = Field(default=None, description="Original config object")
+    provided_hypotheses: list[HypothesisCandidate] = Field(default_factory=list)
     evidence: list[HypothesisEvidence] = Field(default_factory=list)
     candidates: list[HypothesisCandidate] = Field(default_factory=list)
     ranked_candidates: list[HypothesisCandidate] = Field(default_factory=list)
@@ -140,6 +141,27 @@ def _build_failure_payload(state: HypothesisWorkflowState) -> dict[str, Any]:
     }
 
 
+def _normalize_mode(mode: str | None) -> str:
+    normalized = (mode or "generate").strip().lower()
+    aliases = {
+        "generate": "generate",
+        "generation": "generate",
+        "testing": "testing",
+        "generate_and_plan_tests": "testing",
+        "full": "full",
+    }
+    return aliases.get(normalized, "generate")
+
+
+def _normalize_hypothesis_candidates(items: list[Any]) -> list[HypothesisCandidate]:
+    return [
+        item
+        if isinstance(item, HypothesisCandidate)
+        else HypothesisCandidate.model_validate(item)
+        for item in items
+    ]
+
+
 class ParseHypothesisRequest(BaseNode[HypothesisWorkflowState]):  # type: ignore[unsupported-base]
     """Validate and normalize workflow inputs."""
 
@@ -148,20 +170,27 @@ class ParseHypothesisRequest(BaseNode[HypothesisWorkflowState]):  # type: ignore
     ) -> GatherEvidence | End[dict[str, Any]]:
         state = ctx.state
         question = state.question.strip()
-        if not question:
+        if not question and not state.provided_hypotheses:
             _mark_failure(
                 state,
-                "Question cannot be empty",
+                "Question cannot be empty unless hypotheses are provided",
                 stage="request_parsing",
             )
             return End(_build_failure_payload(state))
 
-        state.question = question
-        state.max_hypotheses = max(1, int(state.max_hypotheses))
-        state.top_k = max(1, min(int(state.top_k), state.max_hypotheses))
-        state.generate_testing_plans = (
-            state.generate_testing_plans or state.mode == "generate_and_plan_tests"
+        state.question = question or "Provided hypotheses"
+        state.mode = _normalize_mode(state.mode)
+        state.max_hypotheses = max(
+            1, int(state.max_hypotheses), len(state.provided_hypotheses)
         )
+        state.top_k = max(1, min(int(state.top_k), state.max_hypotheses))
+        state.generate_testing_plans = state.generate_testing_plans or state.mode in {
+            "testing",
+            "full",
+        }
+        if state.provided_hypotheses:
+            state.candidates = list(state.provided_hypotheses)
+            state.metadata["used_provided_hypotheses"] = True
         state.status = ExecutionStatus.RUNNING
         return GatherEvidence()
 
@@ -206,6 +235,8 @@ class GenerateHypotheses(BaseNode[HypothesisWorkflowState]):  # type: ignore[uns
         self, ctx: GraphRunContext[HypothesisWorkflowState]
     ) -> ScoreAndRankHypotheses | HypothesisError:
         state = ctx.state
+        if state.candidates:
+            return ScoreAndRankHypotheses()
         try:
             generator = HypothesisGeneratorAgent()
             state.candidates = generator.generate(
@@ -381,7 +412,7 @@ def _build_testing_environments(
                         candidate.score.overall_score if candidate.score else None
                     ),
                 },
-                status=WorkflowStatus.COMPLETED,
+                status=WorkflowStatus.PENDING,
             )
         )
     return environments
@@ -407,6 +438,7 @@ async def run_hypothesis_workflow(
     question: str,
     cfg: Any | None = None,
     mode: str | None = None,
+    existing_hypotheses: list[dict[str, Any]] | list[HypothesisCandidate] | None = None,
 ) -> dict[str, Any]:
     """Run the hypothesis workflow with config-derived defaults."""
 
@@ -417,9 +449,14 @@ async def run_hypothesis_workflow(
     inferred_mode = mode
     if inferred_mode is None:
         if _section_get(testing_cfg, "enabled", False):
-            inferred_mode = "generate_and_plan_tests"
+            inferred_mode = "testing"
         else:
             inferred_mode = _section_get(hypothesis_cfg, "mode", "generate")
+    inferred_mode = _normalize_mode(inferred_mode)
+
+    provided_hypotheses = existing_hypotheses
+    if provided_hypotheses is None:
+        provided_hypotheses = _section_get(hypothesis_cfg, "existing_hypotheses", [])
 
     state = HypothesisWorkflowState(
         question=question,
@@ -432,14 +469,19 @@ async def run_hypothesis_workflow(
         top_k=int(_section_get(hypothesis_cfg, "top_k", 3) or 3),
         generate_testing_plans=bool(
             _section_get(hypothesis_cfg, "generate_testing_plans", False)
-            or inferred_mode == "generate_and_plan_tests"
+            or inferred_mode in {"testing", "full"}
         ),
         score_weights=dict(_section_get(hypothesis_cfg, "score_weights", {}) or {}),
         config=cfg,
+        provided_hypotheses=_normalize_hypothesis_candidates(
+            list(provided_hypotheses or [])
+        ),
     )
     workflow = create_hypothesis_workflow()
     result = await workflow.run(ParseHypothesisRequest(), state=state)  # type: ignore[arg-type]
-    return result.output if hasattr(result, "output") else {"error": "No output"}  # type: ignore[return-value]
+    if not hasattr(result, "output") or not isinstance(result.output, dict):
+        raise RuntimeError("Hypothesis workflow did not return a structured output")
+    return result.output  # type: ignore[return-value]
 
 
 __all__ = [

--- a/configs/hypothesis_bioinformatics_example.yaml
+++ b/configs/hypothesis_bioinformatics_example.yaml
@@ -16,7 +16,7 @@ flows:
     enabled: true
 
 hypothesis:
-  mode: generate_and_plan_tests
+  mode: testing
   max_hypotheses: 4
   top_k: 3
   evidence_mode: search_plus_rag

--- a/configs/statemachines/flows/hypothesis_testing.yaml
+++ b/configs/statemachines/flows/hypothesis_testing.yaml
@@ -1,7 +1,7 @@
 # Hypothesis testing flow compatibility shim
 
 enabled: false
-mode: generate_and_plan_tests
+mode: testing
 generate_testing_plans: true
 engine_config_group: hypothesis/default
 description: "Compatibility flow config for hypothesis generation with validation planning."

--- a/scripts/run_hypothesis_engine.py
+++ b/scripts/run_hypothesis_engine.py
@@ -18,7 +18,7 @@ def build_config(args: argparse.Namespace):
             "workflow_orchestration": {"enabled": False},
             "flows": {
                 "hypothesis_generation": {"enabled": mode == "generate"},
-                "hypothesis_testing": {"enabled": mode == "generate_and_plan_tests"},
+                "hypothesis_testing": {"enabled": mode in {"testing", "full"}},
             },
             "hypothesis": {
                 "mode": mode,
@@ -26,7 +26,7 @@ def build_config(args: argparse.Namespace):
                 "top_k": args.top_k,
                 "evidence_mode": args.evidence_mode,
                 "live_evidence_enabled": False,
-                "generate_testing_plans": mode == "generate_and_plan_tests",
+                "generate_testing_plans": mode in {"testing", "full"},
             },
         }
     )
@@ -39,7 +39,7 @@ def main() -> int:
     parser.add_argument("question", help="Research question to turn into hypotheses")
     parser.add_argument(
         "--mode",
-        choices=["generate", "generate_and_plan_tests"],
+        choices=["generate", "testing", "full"],
         default="generate",
         help="Hypothesis workflow mode",
     )

--- a/scripts/test/run_hypothesis_smoke.py
+++ b/scripts/test/run_hypothesis_smoke.py
@@ -19,7 +19,7 @@ def main() -> int:
                 "hypothesis_testing": {"enabled": True},
             },
             "hypothesis": {
-                "mode": "generate_and_plan_tests",
+                "mode": "testing",
                 "max_hypotheses": 3,
                 "top_k": 2,
                 "evidence_mode": "search_only",
@@ -32,7 +32,7 @@ def main() -> int:
         run_hypothesis_workflow(
             "What mechanisms could explain why sleep quality affects memory performance?",
             cfg,
-            mode="generate_and_plan_tests",
+            mode="testing",
         )
     )
     hypotheses = result.get("ranked_hypotheses", [])

--- a/tests/imports/test_datatypes_imports.py
+++ b/tests/imports/test_datatypes_imports.py
@@ -150,6 +150,23 @@ class TestDatatypesModuleImports:
         assert HypothesisTestPlan is not None
         assert HypothesisWorkflowResult is not None
 
+    def test_hypothesis_package_exports(self):
+        """Test package-level exports for hypothesis datatypes."""
+
+        from DeepResearch.src.datatypes import (
+            HypothesisCandidate,
+            HypothesisEvidence,
+            HypothesisScore,
+            HypothesisTestPlan,
+            HypothesisWorkflowResult,
+        )
+
+        assert HypothesisEvidence is not None
+        assert HypothesisCandidate is not None
+        assert HypothesisScore is not None
+        assert HypothesisTestPlan is not None
+        assert HypothesisWorkflowResult is not None
+
     def test_vllm_integration_imports(self):
         """Test all imports from vllm_integration module."""
 

--- a/tests/imports/test_tools_imports.py
+++ b/tests/imports/test_tools_imports.py
@@ -765,7 +765,9 @@ class TestToolsImportErrorHandling:
 
     def test_tools_package_unknown_attribute_raises_attribute_error(self):
         """Unknown lazy exports should raise AttributeError."""
-        import DeepResearch.src.tools as tools
+        from operator import attrgetter
+
+        from DeepResearch.src import tools
 
         with pytest.raises(AttributeError):
-            getattr(tools, "not_a_real_tool_module")
+            attrgetter("not_a_real_tool_module")(tools)

--- a/tests/imports/test_tools_imports.py
+++ b/tests/imports/test_tools_imports.py
@@ -104,8 +104,17 @@ class TestToolsModuleImports:
         from DeepResearch.src.tools import registry
 
         assert registry is not None
+        assert "generate_hypotheses" in registry.list()
         assert "go_annotation_processor" in registry.list()
         assert "pubmed_retriever" in registry.list()
+
+    def test_hypothesis_tools_module_imports(self):
+        """Test lazy access to the hypothesis tools module."""
+
+        from DeepResearch.src.tools import hypothesis_tools
+
+        assert hypothesis_tools is not None
+        assert hasattr(hypothesis_tools, "GenerateHypothesesTool")
 
     def test_tools_datatypes_imports(self):
         """Test all imports from tools datatypes module."""

--- a/tests/imports/test_tools_imports.py
+++ b/tests/imports/test_tools_imports.py
@@ -762,3 +762,10 @@ class TestToolsImportErrorHandling:
         assert spec is not None
         assert spec.name == "test_tool"
         assert "param" in spec.inputs
+
+    def test_tools_package_unknown_attribute_raises_attribute_error(self):
+        """Unknown lazy exports should raise AttributeError."""
+        import DeepResearch.src.tools as tools
+
+        with pytest.raises(AttributeError):
+            getattr(tools, "not_a_real_tool_module")

--- a/tests/test_examples/test_hypothesis_engine.py
+++ b/tests/test_examples/test_hypothesis_engine.py
@@ -23,6 +23,15 @@ def test_hypothesis_example_config_composes(config_dir):
     assert "output_format" not in cfg.hypothesis
 
 
+def test_hypothesis_bioinformatics_example_config_composes(config_dir):
+    with initialize_config_dir(version_base=None, config_dir=config_dir):
+        cfg = compose(config_name="hypothesis_bioinformatics_example")
+
+    assert cfg.flows.hypothesis_testing.enabled is True
+    assert cfg.workflow_orchestration.enabled is False
+    assert cfg.hypothesis.mode == "testing"
+
+
 def test_run_graph_with_hypothesis_example_config(config_dir, monkeypatch):
     monkeypatch.setattr(
         "DeepResearch.src.tools.hypothesis_tools.GatherEvidenceTool._collect_external_evidence",

--- a/tests/test_examples/test_hypothesis_engine.py
+++ b/tests/test_examples/test_hypothesis_engine.py
@@ -2,7 +2,9 @@ from pathlib import Path
 
 import pytest
 from hydra import compose, initialize_config_dir
+from omegaconf import OmegaConf
 
+from DeepResearch import hypothesis_app
 from DeepResearch.app import run_graph
 
 
@@ -45,3 +47,20 @@ def test_run_graph_with_hypothesis_example_config(config_dir, monkeypatch):
 
     assert "Hypothesis Engine Report" in output
     assert "Ranked Hypotheses" in output
+
+
+def test_hypothesis_app_main_uses_default_question_and_prints_report(
+    monkeypatch, capsys
+):
+    captured = {}
+
+    async def fake_run(question, cfg):
+        captured["question"] = question
+        return {"markdown_report": "CLI hypothesis report"}
+
+    monkeypatch.setattr(hypothesis_app, "run_hypothesis_workflow", fake_run)
+
+    hypothesis_app.main.__wrapped__(OmegaConf.create({}))
+
+    assert captured["question"] == "What hypotheses best explain this outcome?"
+    assert capsys.readouterr().out.strip() == "CLI hypothesis report"

--- a/tests/test_hypothesis_agents.py
+++ b/tests/test_hypothesis_agents.py
@@ -1,0 +1,87 @@
+import pytest
+
+from DeepResearch.src.agents.hypothesis_agents import (
+    HypothesisEvaluatorAgent,
+    HypothesisGeneratorAgent,
+    HypothesisPlannerAgent,
+)
+from DeepResearch.src.datatypes.hypothesis import (
+    HypothesisCandidate,
+    HypothesisEvidence,
+)
+from DeepResearch.src.tools.base import ExecutionResult
+
+
+def _sample_evidence() -> list[HypothesisEvidence]:
+    return [
+        HypothesisEvidence(
+            source_id="ev-1",
+            source_type="question",
+            title="Question framing",
+            summary="The question ties a plausible driver to a measurable outcome.",
+            relevance=0.9,
+        )
+    ]
+
+
+def _sample_candidate() -> HypothesisCandidate:
+    return HypothesisCandidate(
+        id="hyp-1",
+        statement="Spacing study sessions improves long-term recall.",
+        rationale="The intervention and outcome are both measurable.",
+        assumptions=["Spacing is measurable."],
+        predictions=["Recall improves after spaced practice."],
+        supporting_evidence=["ev-1"],
+        counter_evidence=["No recall gain after spacing."],
+        keywords=["spacing", "long-term recall", "practice"],
+    )
+
+
+def test_hypothesis_generator_agent_raises_default_error_on_tool_failure(monkeypatch):
+    monkeypatch.setattr(
+        "DeepResearch.src.tools.hypothesis_tools.GenerateHypothesesTool.run",
+        lambda self, params: ExecutionResult(success=False, error=None),
+    )
+
+    with pytest.raises(ValueError, match="Hypothesis generation failed"):
+        HypothesisGeneratorAgent().generate(
+            "Why does spacing help memory?", _sample_evidence(), 2
+        )
+
+
+def test_hypothesis_evaluator_agent_raises_default_error_on_tool_failure(monkeypatch):
+    monkeypatch.setattr(
+        "DeepResearch.src.tools.hypothesis_tools.ScoreHypothesesTool.run",
+        lambda self, params: ExecutionResult(success=False, error=None),
+    )
+
+    with pytest.raises(ValueError, match="Hypothesis scoring failed"):
+        HypothesisEvaluatorAgent().rank([_sample_candidate()], 1)
+
+
+def test_hypothesis_planner_agent_raises_default_error_for_plan_failures(monkeypatch):
+    monkeypatch.setattr(
+        "DeepResearch.src.tools.hypothesis_tools.CreateHypothesisTestPlansTool.run",
+        lambda self, params: ExecutionResult(success=False, error=None),
+    )
+
+    with pytest.raises(ValueError, match="Hypothesis test-plan generation failed"):
+        HypothesisPlannerAgent().create_test_plans([_sample_candidate()])
+
+
+def test_hypothesis_planner_agent_raises_default_error_for_report_failures(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "DeepResearch.src.tools.hypothesis_tools.FormatHypothesisReportTool.run",
+        lambda self, params: ExecutionResult(success=False, error=None),
+    )
+
+    with pytest.raises(ValueError, match="Hypothesis report formatting failed"):
+        HypothesisPlannerAgent().format_report(
+            question="Why does spacing help memory?",
+            mode="generate",
+            evidence=_sample_evidence(),
+            hypotheses=[_sample_candidate()],
+            test_plans=[],
+        )

--- a/tests/test_statemachines/test_hypothesis_workflow.py
+++ b/tests/test_statemachines/test_hypothesis_workflow.py
@@ -10,7 +10,12 @@ from DeepResearch.src.datatypes.workflow_orchestration import (
     WorkflowOrchestrationConfig,
     WorkflowType,
 )
-from DeepResearch.src.statemachines.hypothesis_workflow import run_hypothesis_workflow
+from DeepResearch.src.statemachines.hypothesis_workflow import (
+    _build_testing_environments,
+    _section_get,
+    run_hypothesis_workflow,
+)
+from DeepResearch.src.tools.base import ExecutionResult
 
 
 @pytest.mark.asyncio
@@ -321,3 +326,198 @@ async def test_hypothesis_run_records_structured_failure_without_success_note(
         note == "Hypothesis workflow completed successfully" for note in state.notes
     )
     assert any("completed with failure status" in note for note in state.notes)
+
+
+def test_section_get_supports_none_dict_and_broken_getters():
+    class BrokenGetter:
+        hypothesis_mode = "testing"
+
+        def get(self, key, default=None):
+            raise RuntimeError("getter failed")
+
+    assert _section_get(None, "missing", "fallback") == "fallback"
+    assert _section_get({"mode": "generate"}, "mode", "fallback") == "generate"
+    assert _section_get(BrokenGetter(), "hypothesis_mode", "fallback") == "testing"
+
+
+@pytest.mark.asyncio
+async def test_hypothesis_workflow_rejects_blank_question_without_hypotheses():
+    result = await run_hypothesis_workflow("", OmegaConf.create({}))
+
+    assert result["status"] == "failed"
+    assert result["metadata"]["failure_stage"] == "request_parsing"
+    assert "Question cannot be empty" in result["errors"][-1]
+
+
+@pytest.mark.asyncio
+async def test_hypothesis_workflow_records_evidence_gathering_failure(monkeypatch):
+    monkeypatch.setattr(
+        "DeepResearch.src.statemachines.hypothesis_workflow.GatherEvidenceTool.run",
+        lambda self, params: ExecutionResult(
+            success=False, error="evidence unavailable"
+        ),
+    )
+
+    result = await run_hypothesis_workflow(
+        "Why does retrieval practice improve memory?", OmegaConf.create({})
+    )
+
+    assert result["status"] == "failed"
+    assert result["metadata"]["failure_stage"] == "evidence_gathering"
+
+
+@pytest.mark.asyncio
+async def test_hypothesis_workflow_records_generation_failure(monkeypatch):
+    monkeypatch.setattr(
+        "DeepResearch.src.agents.hypothesis_agents.HypothesisGeneratorAgent.generate",
+        lambda self, question, evidence, max_hypotheses: (_ for _ in ()).throw(
+            RuntimeError("generator unavailable")
+        ),
+    )
+
+    result = await run_hypothesis_workflow(
+        "Why does retrieval practice improve memory?", OmegaConf.create({})
+    )
+
+    assert result["status"] == "failed"
+    assert result["metadata"]["failure_stage"] == "hypothesis_generation"
+
+
+@pytest.mark.asyncio
+async def test_hypothesis_workflow_records_ranking_failure(monkeypatch):
+    monkeypatch.setattr(
+        "DeepResearch.src.tools.hypothesis_tools.GatherEvidenceTool._collect_external_evidence",
+        lambda self, question, evidence_mode: [],
+    )
+    monkeypatch.setattr(
+        "DeepResearch.src.agents.hypothesis_agents.HypothesisEvaluatorAgent.rank",
+        lambda self, candidates, top_k, score_weights=None: (_ for _ in ()).throw(
+            RuntimeError("ranking unavailable")
+        ),
+    )
+
+    result = await run_hypothesis_workflow(
+        "Why does retrieval practice improve memory?", OmegaConf.create({})
+    )
+
+    assert result["status"] == "failed"
+    assert result["metadata"]["failure_stage"] == "hypothesis_ranking"
+
+
+@pytest.mark.asyncio
+async def test_hypothesis_workflow_records_test_plan_failure(monkeypatch):
+    monkeypatch.setattr(
+        "DeepResearch.src.tools.hypothesis_tools.GatherEvidenceTool._collect_external_evidence",
+        lambda self, question, evidence_mode: [],
+    )
+    monkeypatch.setattr(
+        "DeepResearch.src.agents.hypothesis_agents.HypothesisPlannerAgent.create_test_plans",
+        lambda self, candidates: (_ for _ in ()).throw(
+            RuntimeError("planner unavailable")
+        ),
+    )
+
+    cfg = OmegaConf.create({"hypothesis": {"mode": "testing"}})
+    result = await run_hypothesis_workflow(
+        "Why does retrieval practice improve memory?", cfg
+    )
+
+    assert result["status"] == "failed"
+    assert result["metadata"]["failure_stage"] == "test_plan_creation"
+
+
+def test_build_testing_environments_skips_unmatched_plans():
+    state = SimpleNamespace(
+        test_plans=[
+            SimpleNamespace(
+                hypothesis_id="missing-hypothesis",
+                test_type="comparative validation study",
+                method="Do the experiment",
+                required_inputs=["input"],
+                success_criteria=["criterion"],
+            )
+        ],
+        ranked_candidates=[],
+    )
+
+    assert _build_testing_environments(state) == []
+
+
+@pytest.mark.asyncio
+async def test_run_hypothesis_workflow_raises_on_non_dict_output(monkeypatch):
+    class FakeGraph:
+        async def run(self, *args, **kwargs):
+            return SimpleNamespace(output="not-a-dict")
+
+    monkeypatch.setattr(
+        "DeepResearch.src.statemachines.hypothesis_workflow.create_hypothesis_workflow",
+        lambda: FakeGraph(),
+    )
+
+    with pytest.raises(RuntimeError, match="structured output"):
+        await run_hypothesis_workflow(
+            "Why does spacing help memory?", OmegaConf.create({})
+        )
+
+
+@pytest.mark.asyncio
+async def test_hypothesis_run_uses_default_messages_and_exception_fallback(
+    monkeypatch,
+):
+    async def no_report_success(question, cfg, mode=None):
+        return {
+            "status": "success",
+            "errors": [],
+            "dataset": None,
+            "testing_environments": [],
+        }
+
+    monkeypatch.setattr(
+        "DeepResearch.src.statemachines.hypothesis_workflow.run_hypothesis_workflow",
+        no_report_success,
+    )
+
+    success_state = ResearchState(question="Test question", config=OmegaConf.create({}))
+    success_ctx = SimpleNamespace(state=success_state)
+    success_final = await HypothesisRun().run(success_ctx)
+
+    assert success_final.data == "Hypothesis analysis completed."
+    assert success_state.answers[-1] == "Hypothesis analysis completed."
+
+    async def no_report_failure(question, cfg, mode=None):
+        return {
+            "status": "failed",
+            "errors": ["ranker offline"],
+            "dataset": None,
+            "testing_environments": [],
+        }
+
+    monkeypatch.setattr(
+        "DeepResearch.src.statemachines.hypothesis_workflow.run_hypothesis_workflow",
+        no_report_failure,
+    )
+
+    failure_state = ResearchState(question="Test question", config=OmegaConf.create({}))
+    failure_ctx = SimpleNamespace(state=failure_state)
+    failure_final = await HypothesisRun().run(failure_ctx)
+
+    assert failure_final.data == "Hypothesis workflow failed: ranker offline"
+    assert any(
+        "completed with failure status: ranker offline" in note
+        for note in failure_state.notes
+    )
+
+    async def raise_error(question, cfg, mode=None):
+        raise RuntimeError("executor blew up")
+
+    monkeypatch.setattr(
+        "DeepResearch.src.statemachines.hypothesis_workflow.run_hypothesis_workflow",
+        raise_error,
+    )
+
+    error_state = ResearchState(question="Test question", config=OmegaConf.create({}))
+    error_ctx = SimpleNamespace(state=error_state)
+    error_final = await HypothesisRun().run(error_ctx)
+
+    assert error_final.data == "Error: Hypothesis workflow failed: executor blew up"
+    assert error_state.answers[-1] == error_final.data

--- a/tests/test_statemachines/test_hypothesis_workflow.py
+++ b/tests/test_statemachines/test_hypothesis_workflow.py
@@ -62,7 +62,7 @@ async def test_hypothesis_workflow_testing_mode_returns_plans(monkeypatch):
                 "hypothesis_testing": {"enabled": True},
             },
             "hypothesis": {
-                "mode": "generate_and_plan_tests",
+                "mode": "testing",
                 "max_hypotheses": 3,
                 "top_k": 2,
                 "evidence_mode": "search_only",
@@ -79,6 +79,10 @@ async def test_hypothesis_workflow_testing_mode_returns_plans(monkeypatch):
     assert len(result["ranked_hypotheses"]) == 2
     assert len(result["test_plans"]) == 2
     assert len(result["testing_environments"]) == 2
+    assert all(
+        environment["status"] == "pending"
+        for environment in result["testing_environments"]
+    )
 
 
 @pytest.mark.asyncio
@@ -222,8 +226,66 @@ async def test_orchestrator_testing_delegates_to_shared_workflow(monkeypatch):
 
     assert result == {"markdown_report": "ok"}
     assert captured["question"] == "What mechanisms explain sleep and memory?"
-    assert captured["mode"] == "generate_and_plan_tests"
+    assert captured["mode"] == "testing"
     assert captured["generate_testing_plans"] is True
+
+
+@pytest.mark.asyncio
+async def test_hypothesis_workflow_can_rank_provided_hypotheses(monkeypatch):
+    monkeypatch.setattr(
+        "DeepResearch.src.tools.hypothesis_tools.GatherEvidenceTool._collect_external_evidence",
+        lambda self, question, evidence_mode: [],
+    )
+
+    cfg = OmegaConf.create(
+        {
+            "workflow_orchestration": {"enabled": False},
+            "flows": {
+                "hypothesis_generation": {"enabled": False},
+                "hypothesis_testing": {"enabled": True},
+            },
+            "hypothesis": {
+                "mode": "testing",
+                "top_k": 2,
+                "generate_testing_plans": True,
+            },
+        }
+    )
+
+    provided_hypotheses = [
+        {
+            "id": "hyp-1",
+            "statement": "Targeted feedback improves retention by reinforcing retrieval cues.",
+            "rationale": "Grounded in retrieval-practice evidence.",
+            "assumptions": ["Feedback timing is measurable."],
+            "predictions": ["Retention improves when feedback is timely."],
+            "supporting_evidence": ["ev-1", "ev-2"],
+            "counter_evidence": ["No retention change would weaken the hypothesis."],
+            "keywords": ["targeted feedback", "retention"],
+        },
+        {
+            "id": "hyp-2",
+            "statement": "Targeted feedback reduces confusion by clarifying misconceptions.",
+            "rationale": "Grounded in misconception-correction evidence.",
+            "assumptions": ["Confusion can be measured."],
+            "predictions": ["Learners make fewer repeated mistakes."],
+            "supporting_evidence": ["ev-3"],
+            "counter_evidence": ["No change in mistakes would weaken the hypothesis."],
+            "keywords": ["targeted feedback", "misconceptions"],
+        },
+    ]
+
+    result = await run_hypothesis_workflow(
+        "",
+        cfg,
+        mode="testing",
+        existing_hypotheses=provided_hypotheses,
+    )
+
+    assert result["status"] == "success"
+    assert result["metadata"]["used_provided_hypotheses"] is True
+    assert len(result["ranked_hypotheses"]) == 2
+    assert len(result["test_plans"]) == 2
 
 
 @pytest.mark.asyncio
@@ -233,9 +295,7 @@ async def test_hypothesis_run_records_structured_failure_without_success_note(
     async def fake_run(question, cfg, mode=None):
         return {
             "status": "failed",
-            "errors": [
-                "Hypothesis report synthesis failed: report formatter unavailable"
-            ],
+            "errors": ["Hypothesis report synthesis failed: report formatter unavailable"],
             "markdown_report": (
                 "Hypothesis workflow failed: report formatter unavailable"
             ),
@@ -258,4 +318,6 @@ async def test_hypothesis_run_records_structured_failure_without_success_note(
     assert not any(
         note == "Hypothesis workflow completed successfully" for note in state.notes
     )
-    assert any("completed with failure status" in note for note in state.notes)
+    assert any(
+        "completed with failure status" in note for note in state.notes
+    )

--- a/tests/test_statemachines/test_hypothesis_workflow.py
+++ b/tests/test_statemachines/test_hypothesis_workflow.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 from omegaconf import OmegaConf
@@ -150,7 +151,7 @@ async def test_plan_routes_to_hypothesis_before_orchestration():
     state = ResearchState(question="Test question", config=cfg)
     ctx = SimpleNamespace(state=state)
 
-    next_node = await Plan().run(ctx)
+    next_node = await Plan().run(cast(Any, ctx))  # noqa: TC006
 
     assert isinstance(next_node, HypothesisRun)
 
@@ -318,7 +319,7 @@ async def test_hypothesis_run_records_structured_failure_without_success_note(
     state = ResearchState(question="Test question", config=OmegaConf.create({}))
     ctx = SimpleNamespace(state=state)
 
-    final = await HypothesisRun().run(ctx)
+    final = await HypothesisRun().run(cast(Any, ctx))  # noqa: TC006
 
     assert final.data == "Hypothesis workflow failed: report formatter unavailable"
     assert state.answers[-1] == final.data
@@ -440,7 +441,7 @@ def test_build_testing_environments_skips_unmatched_plans():
         ranked_candidates=[],
     )
 
-    assert _build_testing_environments(state) == []
+    assert _build_testing_environments(cast(Any, state)) == []  # noqa: TC006
 
 
 @pytest.mark.asyncio
@@ -479,7 +480,7 @@ async def test_hypothesis_run_uses_default_messages_and_exception_fallback(
 
     success_state = ResearchState(question="Test question", config=OmegaConf.create({}))
     success_ctx = SimpleNamespace(state=success_state)
-    success_final = await HypothesisRun().run(success_ctx)
+    success_final = await HypothesisRun().run(cast(Any, success_ctx))  # noqa: TC006
 
     assert success_final.data == "Hypothesis analysis completed."
     assert success_state.answers[-1] == "Hypothesis analysis completed."
@@ -499,7 +500,7 @@ async def test_hypothesis_run_uses_default_messages_and_exception_fallback(
 
     failure_state = ResearchState(question="Test question", config=OmegaConf.create({}))
     failure_ctx = SimpleNamespace(state=failure_state)
-    failure_final = await HypothesisRun().run(failure_ctx)
+    failure_final = await HypothesisRun().run(cast(Any, failure_ctx))  # noqa: TC006
 
     assert failure_final.data == "Hypothesis workflow failed: ranker offline"
     assert any(
@@ -517,7 +518,7 @@ async def test_hypothesis_run_uses_default_messages_and_exception_fallback(
 
     error_state = ResearchState(question="Test question", config=OmegaConf.create({}))
     error_ctx = SimpleNamespace(state=error_state)
-    error_final = await HypothesisRun().run(error_ctx)
+    error_final = await HypothesisRun().run(cast(Any, error_ctx))  # noqa: TC006
 
     assert error_final.data == "Error: Hypothesis workflow failed: executor blew up"
     assert error_state.answers[-1] == error_final.data

--- a/tests/test_statemachines/test_hypothesis_workflow.py
+++ b/tests/test_statemachines/test_hypothesis_workflow.py
@@ -295,7 +295,9 @@ async def test_hypothesis_run_records_structured_failure_without_success_note(
     async def fake_run(question, cfg, mode=None):
         return {
             "status": "failed",
-            "errors": ["Hypothesis report synthesis failed: report formatter unavailable"],
+            "errors": [
+                "Hypothesis report synthesis failed: report formatter unavailable"
+            ],
             "markdown_report": (
                 "Hypothesis workflow failed: report formatter unavailable"
             ),
@@ -318,6 +320,4 @@ async def test_hypothesis_run_records_structured_failure_without_success_note(
     assert not any(
         note == "Hypothesis workflow completed successfully" for note in state.notes
     )
-    assert any(
-        "completed with failure status" in note for note in state.notes
-    )
+    assert any("completed with failure status" in note for note in state.notes)

--- a/tests/test_tools/test_hypothesis_tools.py
+++ b/tests/test_tools/test_hypothesis_tools.py
@@ -1,8 +1,8 @@
 from DeepResearch.src.datatypes.hypothesis import HypothesisCandidate
 from DeepResearch.src.tools.base import ExecutionResult
 from DeepResearch.src.tools.hypothesis_tools import (
-    FormatHypothesisReportTool,
     CreateHypothesisTestPlansTool,
+    FormatHypothesisReportTool,
     GatherEvidenceTool,
     GenerateHypothesesTool,
     ScoreHypothesesTool,

--- a/tests/test_tools/test_hypothesis_tools.py
+++ b/tests/test_tools/test_hypothesis_tools.py
@@ -1,5 +1,7 @@
 from DeepResearch.src.datatypes.hypothesis import HypothesisCandidate
+from DeepResearch.src.tools.base import ExecutionResult
 from DeepResearch.src.tools.hypothesis_tools import (
+    FormatHypothesisReportTool,
     CreateHypothesisTestPlansTool,
     GatherEvidenceTool,
     GenerateHypothesesTool,
@@ -24,6 +26,15 @@ class TestHypothesisTools:
         assert keywords[:2] == ["sleep quality", "memory performance"]
         assert "affects" not in keywords[:2]
 
+    def test_extract_keywords_uses_default_focus_terms_for_sparse_questions(self):
+        keywords = extract_keywords("Why?", limit=3)
+
+        assert keywords == [
+            "baseline conditions",
+            "time scale",
+            "measurement context",
+        ]
+
     def test_gather_evidence_returns_question_driven_fallbacks(self, monkeypatch):
         monkeypatch.setattr(
             "DeepResearch.src.tools.hypothesis_tools.GatherEvidenceTool._collect_external_evidence",
@@ -42,6 +53,84 @@ class TestHypothesisTools:
         assert len(evidence) >= 3
         assert evidence[0]["source_type"] == "question"
         assert result.data["used_external_evidence"] is False
+
+    def test_gather_evidence_rejects_missing_or_blank_questions(self):
+        missing = GatherEvidenceTool().run({})
+        blank = GatherEvidenceTool().run({"question": "   "})
+
+        assert missing.success is False
+        assert blank.success is False
+
+    def test_gather_evidence_collects_search_and_rag_results(self, monkeypatch):
+        monkeypatch.setenv("DEEPCRITICAL_ENABLE_LIVE_EVIDENCE", "true")
+
+        def fake_search_run(self, params):
+            return ExecutionResult(
+                success=True,
+                data={
+                    "documents": [
+                        {
+                            "content": (
+                                "Evidence from the search result about memory retention."
+                            ),
+                            "metadata": {
+                                "source_title": "Search study",
+                                "url": "https://example.com/search",
+                            },
+                        },
+                        {
+                            "content": "   ",
+                            "metadata": {"source_title": "Ignored empty result"},
+                        },
+                    ]
+                },
+            )
+
+        def fake_rag_run(self, params):
+            return ExecutionResult(
+                success=True,
+                data={
+                    "documents": [
+                        {
+                            "content": (
+                                "RAG retrieved supporting material about spaced repetition."
+                            ),
+                            "metadata": {
+                                "source_title": "RAG source",
+                                "source": "rag://memory",
+                            },
+                        }
+                    ]
+                },
+            )
+
+        monkeypatch.setattr(
+            "DeepResearch.src.tools.integrated_search_tools.IntegratedSearchTool.run",
+            fake_search_run,
+        )
+        monkeypatch.setattr(
+            "DeepResearch.src.tools.integrated_search_tools.RAGSearchTool.run",
+            fake_rag_run,
+        )
+
+        tool = GatherEvidenceTool()
+        assert tool._is_live_evidence_enabled(None) is True
+
+        result = tool.run(
+            {
+                "question": "Why does spaced repetition improve recall?",
+                "evidence_mode": "search_plus_rag",
+                "live_evidence_enabled": "yes",
+                "max_evidence_items": 5,
+            }
+        )
+
+        assert result.success is True
+        evidence = result.data["evidence"]
+        assert result.data["used_external_evidence"] is True
+        assert any(item["source_type"] == "search" for item in evidence)
+        assert any(item["source_type"] == "rag" for item in evidence)
+        assert not any(item["title"] == "Ignored empty result" for item in evidence)
 
     def test_score_hypotheses_ranks_candidates_deterministically(self):
         stronger = HypothesisCandidate(
@@ -82,6 +171,33 @@ class TestHypothesisTools:
             ranked[0]["score"]["overall_score"] >= ranked[1]["score"]["overall_score"]
         )
 
+    def test_score_hypotheses_handles_empty_input_and_invalid_weights(self):
+        empty_result = ScoreHypothesesTool().run({"hypotheses": []})
+        assert empty_result.success is False
+
+        candidate = HypothesisCandidate(
+            id="hyp-weights",
+            statement="A measured intervention shifts a measurable outcome.",
+            rationale="Grounded in a structured comparison.",
+            assumptions=["The intervention is measurable."],
+            predictions=["The outcome changes in the expected direction."],
+            supporting_evidence=["ev-1"],
+            counter_evidence=["No observed change would weaken the claim."],
+            keywords=["intervention", "outcome", "comparison"],
+        )
+
+        weighted_result = ScoreHypothesesTool().run(
+            {
+                "hypotheses": [candidate.model_dump()],
+                "score_weights": {"novelty": "bad-value"},
+            }
+        )
+
+        assert weighted_result.success is True
+        assert (
+            weighted_result.data["ranked_hypotheses"][0]["score"]["overall_score"] > 0
+        )
+
     def test_generate_hypotheses_anchors_driver_and_outcome_terms(self):
         result = GenerateHypothesesTool().run(
             {
@@ -96,6 +212,13 @@ class TestHypothesisTools:
         assert "spaced repetition" in hypotheses[0]["statement"].lower()
         assert "recall" in hypotheses[0]["statement"].lower()
         assert "improve" not in hypotheses[0]["keywords"][:2]
+
+    def test_generate_hypotheses_rejects_missing_or_blank_questions(self):
+        missing = GenerateHypothesesTool().run({})
+        blank = GenerateHypothesesTool().run({"question": "   "})
+
+        assert missing.success is False
+        assert blank.success is False
 
     def test_create_test_plans_returns_required_fields(self):
         candidate = HypothesisCandidate(
@@ -118,3 +241,60 @@ class TestHypothesisTools:
         assert plan["hypothesis_id"] == "hyp-1"
         assert len(plan["required_inputs"]) >= 3
         assert len(plan["success_criteria"]) >= 2
+
+    def test_create_test_plans_supports_keyword_fallback_and_empty_input(self):
+        empty = CreateHypothesisTestPlansTool().run({"hypotheses": []})
+        assert empty.success is False
+
+        candidate = HypothesisCandidate(
+            id="hyp-fallback",
+            statement="Improved tutoring cadence changes learner confidence.",
+            rationale="Cadence and confidence are observable.",
+            assumptions=["Cadence is measurable."],
+            predictions=["Confidence rises when cadence improves."],
+            supporting_evidence=["ev-1"],
+            counter_evidence=["Confidence stays flat."],
+            keywords=[],
+        )
+
+        result = CreateHypothesisTestPlansTool().run(
+            {"hypotheses": [candidate.model_dump()]}
+        )
+
+        assert result.success is True
+        method = result.data["test_plans"][0]["method"]
+        assert "tutoring cadence" in method
+        assert "learner confidence" in method
+
+    def test_format_report_handles_empty_evidence_and_missing_question(self):
+        missing = FormatHypothesisReportTool().run({})
+        blank = FormatHypothesisReportTool().run({"question": "   ", "hypotheses": []})
+
+        assert missing.success is False
+        assert blank.success is False
+
+        candidate = HypothesisCandidate(
+            id="hyp-report",
+            statement="Spaced repetition improves long-term recall.",
+            rationale="Supported by question framing.",
+            assumptions=["Spacing intervals can be controlled."],
+            predictions=["Recall improves after spaced review."],
+            supporting_evidence=["ev-1"],
+            counter_evidence=["No recall gain after spacing."],
+            keywords=["spaced repetition", "long-term recall", "review interval"],
+        )
+
+        report = FormatHypothesisReportTool().run(
+            {
+                "question": "Why does spaced repetition improve recall?",
+                "mode": "testing",
+                "hypotheses": [candidate.model_dump()],
+                "test_plans": CreateHypothesisTestPlansTool()
+                .run({"hypotheses": [candidate.model_dump()]})
+                .data["test_plans"],
+            }
+        )
+
+        assert report.success is True
+        assert "No external evidence was available" in report.data["markdown_report"]
+        assert "## Test Plans" in report.data["markdown_report"]


### PR DESCRIPTION
## Summary

This draft PR implements the end-to-end hypothesis workflow for issue #14 on top of the current `main` branch snapshot.

It adds a shared hypothesis engine that supports both hypothesis generation and hypothesis testing, wires that engine into the application and orchestration layers, and adds the supporting configs, scripts, and focused tests needed to exercise the flow.

## What Changed

- add shared hypothesis datatypes, prompts, agents, tools, and a dedicated hypothesis workflow state machine
- add a dedicated `DeepResearch.hypothesis_app` entrypoint and CLI wiring for hypothesis runs
- route explicit hypothesis generation and testing flows through `DeepResearch.app` and the primary workflow orchestrator
- add hypothesis config groups, workflow compatibility shims, and runnable example configs
- harden adjacent integration surfaces uncovered during implementation, including optional tool input validation and lazy tool loading
- add focused import, workflow, tool, and example tests, plus a smoke script for the new workflow

## Why

Issue #14 calls for comprehensive hypothesis testing support. On current `main`, the hypothesis path was still effectively placeholder-backed: the workflow was not fully wired end to end, testing-environment generation was incomplete, and several integration edges around provided hypotheses, routing, and validation still needed real implementation.

This PR closes that gap with a single shared workflow that keeps the implementation cohesive without adding unnecessary orchestration layers.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_statemachines/test_hypothesis_workflow.py tests/test_tools/test_hypothesis_tools.py tests/test_examples/test_hypothesis_engine.py tests/imports/test_app_imports.py tests/imports/test_datatypes_imports.py tests/imports/test_tools_imports.py -q`
- `UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/test/run_hypothesis_smoke.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q`

## Issue

Addresses #14.
