### PR TITLE
Reconcile BioinfoMCP issue #130 registries on demo

### DIFF
--- a/DeepResearch/src/tools/mcp_server_management.py
+++ b/DeepResearch/src/tools/mcp_server_management.py
@@ -33,6 +33,8 @@ from ..tools.bioinformatics.fastqc_server import FastQCServer
 from ..tools.bioinformatics.featurecounts_server import FeatureCountsServer
 from ..tools.bioinformatics.flye_server import FlyeServer
 from ..tools.bioinformatics.freebayes_server import FreeBayesServer
+from ..tools.bioinformatics.gunzip_server import GunzipServer
+from ..tools.bioinformatics.haplotypecaller_server import HaplotypeCallerServer
 from ..tools.bioinformatics.hisat2_server import HISAT2Server
 from ..tools.bioinformatics.kallisto_server import KallistoServer
 from ..tools.bioinformatics.macs3_server import MACS3Server
@@ -167,6 +169,9 @@ SERVER_IMPLEMENTATIONS = {
     # Variant Analysis
     "bcftools": BCFtoolsServer,
     "freebayes": FreeBayesServer,
+    "haplotypecaller": HaplotypeCallerServer,
+    # Compression & Utilities
+    "gunzip": GunzipServer,
     # Multiple Sequence Alignment
     "mafft": MAFFTServer,
 }

--- a/docs/user-guide/tools/bioinformatics.md
+++ b/docs/user-guide/tools/bioinformatics.md
@@ -6,6 +6,27 @@ DeepCritical provides bioinformatics tools for integrative biological data analy
 
 The bioinformatics tools integrate multiple biological databases and provide sophisticated analysis capabilities for gene function prediction, protein analysis, and biological data integration.
 
+## BioinfoMCP Server Catalog
+
+DeepCritical also tracks BioContainers-backed BioinfoMCP tools for issue #130 in `configs/bioinformatics/tools.yaml`. The public issue names are kept as aliases while the runtime uses stable server keys and Python method names.
+
+| Issue tool name | Server key | Method | Current status |
+| --- | --- | --- | --- |
+| `bamCoverage` | `deeptools` | `deeptools_bam_coverage` | Implemented and reconciled through the shared deeptools server |
+| `gatk_HaplotypeCaller` | `haplotypecaller` | `call_variants` | Implemented and reconciled through the HaplotypeCaller server |
+| `gunzip` | `gunzip` | `gunzip_decompress` | Implemented and reconciled through the gunzip server |
+| `mafft` | `mafft` | `mafft_align` | Implemented and reconciled through the MAFFT server |
+| `multiqc` | `multiqc` | `multiqc_run` | Implemented and reconciled through the MultiQC server |
+| `faToTwoBit` | `fatotwobit` | `fatotwobit_convert` | Planned follow-up server |
+| `gatk_ApplyBQSR` | `gatk` | `gatk_apply_bqsr` | Planned follow-up GATK server method |
+| `gatk_BaseRecalibrator` | `gatk` | `gatk_base_recalibrator` | Planned follow-up GATK server method |
+| `gatk_SelectVariants` | `gatk` | `gatk_select_variants` | Planned follow-up GATK server method |
+| `plotCorrelation` | `deeptools` | `deeptools_plot_correlation` | Planned follow-up deeptools method |
+| `quast` | `quast` | `quast_assess` | Planned follow-up server |
+| `trimmomatic` | `trimmomatic` | `trimmomatic_pe` | Planned follow-up server |
+
+Use `mcp_server_list` to discover reconciled server keys and `mcp_server_execute` to call a method after the server is available. Unit tests may use `DEEPC_BIOINFORMATICS_ALLOW_MOCK=1` for command-construction paths when local bioinformatics binaries are unavailable; production runs should provide the real executable or configured container image.
+
 ## Data Sources
 
 ### Gene Ontology (GO)

--- a/tests/test_tools/test_mcp_server_manager.py
+++ b/tests/test_tools/test_mcp_server_manager.py
@@ -13,7 +13,22 @@ from DeepResearch.src.datatypes.mcp import (
     MCPServerStatus,
 )
 from DeepResearch.src.tools.bioinformatics.fastqc_server import FastQCServer
-from DeepResearch.src.tools.mcp_server_tools import MCPServerManager
+from DeepResearch.src.tools.mcp_server_management import SERVER_IMPLEMENTATIONS
+from DeepResearch.src.tools.mcp_server_tools import (
+    MCP_STUB_SERVER_NAMES,
+    MCPServerManager,
+)
+from DeepResearch.src.utils.testcontainers_deployer import (
+    TestcontainersDeployer as MCPTestcontainersDeployer,
+)
+
+ISSUE_130_RECONCILED_SERVER_KEYS = {
+    "deeptools",
+    "gunzip",
+    "haplotypecaller",
+    "mafft",
+    "multiqc",
+}
 
 
 class TestMCPServerManager:
@@ -30,6 +45,23 @@ class TestMCPServerManager:
         assert "gunzip" in servers
         assert "haplotypecaller" in servers
         assert "mafft" in servers
+
+    def test_issue_130_reconciled_servers_are_publicly_discoverable(self):
+        """Existing issue #130 servers are aligned across public registries."""
+        manager = MCPServerManager()
+        deployer = MCPTestcontainersDeployer()
+
+        for server_key in ISSUE_130_RECONCILED_SERVER_KEYS:
+            assert server_key in manager.list_implemented()
+            assert server_key in SERVER_IMPLEMENTATIONS
+            assert server_key in deployer.server_implementations
+            assert server_key not in MCP_STUB_SERVER_NAMES
+
+    def test_management_map_matches_manager_registry(self):
+        """Public management tools do not drift from MCPServerManager keys."""
+        manager = MCPServerManager()
+
+        assert set(SERVER_IMPLEMENTATIONS) == set(manager.servers)
 
     def test_get_server_returns_class_for_valid_name(self, mcp_manager):
         """get_server() returns server class when name exists."""


### PR DESCRIPTION
## Summary

- Add the already-implemented `gunzip` and `haplotypecaller` BioinfoMCP servers to the public `mcp_server_management` implementation map.
- Add registry parity tests so the public management map, `MCPServerManager`, and `TestcontainersDeployer` stay aligned for the already-reconciled issue #130 servers.
- Document the issue #130 BioinfoMCP alias mapping, separating currently reconciled tools from planned follow-up tool servers.

## Why

Issue #130 tracks vendoring BioContainers-backed bioinformatics tools through BioinfoMCP. On `demo`, the catalog and several server implementations already exist, but the public management registry had drifted from `MCPServerManager`: `gunzip` and `haplotypecaller` were implemented yet not discoverable through the public management surface. This PR fixes that reconciliation layer before adding any new tool servers.

## Scope

This PR intentionally does not add new BioContainers servers. Follow-up PRs should still handle missing tools such as `faToTwoBit`, additional GATK methods, `plotCorrelation`, QUAST, and Trimmomatic.

## Validation

- `uv run ruff check DeepResearch/src/tools/mcp_server_management.py tests/test_tools/test_mcp_server_manager.py`
- `uv run pytest tests/test_tools/test_mcp_server_manager.py tests/test_bioinfomcp_catalog.py -q`
- Nearby MCP and reconciled bioinformatics server test slice passed
- Full default `uv run pytest -q` passed with 5 expected skips

Refs #130