### PR TITLE
Fix workflow runtime result scoping on demo

### DIFF
--- a/DeepResearch/src/agents/workflow_orchestrator.py
+++ b/DeepResearch/src/agents/workflow_orchestrator.py
@@ -473,6 +473,7 @@ class PrimaryWorkflowOrchestrator:
     ) -> dict[str, Any]:
         """Execute the primary REACT workflow."""
         start_ts = time.perf_counter()
+        completed_before = len(self.state.completed_executions)
         cfg_dict = self._config_to_dict(config)
         configured_ids = list(self.agent_registry.get("configured_agent_ids", []))
         system_ids = list(self.agent_registry.get("multi_agent_system_ids", []))
@@ -489,38 +490,17 @@ class PrimaryWorkflowOrchestrator:
         )
 
         run_result: Any = None
+        error: str | None = None
+        failure_kind: str | None = None
         try:
-            try:
-                run_result = await self.primary_agent.run(user_input, deps=deps)
-            except AgentRunError as e:
-                elapsed = time.perf_counter() - start_ts
-                return {
-                    "success": False,
-                    "error": str(e),
-                    "result": {"output": None, "usage": None},
-                    "state": self.state,
-                    "execution_metadata": {
-                        "workflows_spawned": len(self.state.active_executions),
-                        "total_executions": len(self.state.completed_executions),
-                        "elapsed_seconds": elapsed,
-                        "failure_kind": "agent_run_error",
-                    },
-                }
-            except Exception as e:
-                elapsed = time.perf_counter() - start_ts
-                logger.exception("Primary workflow agent.run failed")
-                return {
-                    "success": False,
-                    "error": str(e),
-                    "result": {"output": None, "usage": None},
-                    "state": self.state,
-                    "execution_metadata": {
-                        "workflows_spawned": len(self.state.active_executions),
-                        "total_executions": len(self.state.completed_executions),
-                        "elapsed_seconds": elapsed,
-                        "failure_kind": "unexpected_error",
-                    },
-                }
+            run_result = await self.primary_agent.run(user_input, deps=deps)
+        except AgentRunError as e:
+            error = str(e)
+            failure_kind = "agent_run_error"
+        except Exception as e:
+            error = str(e)
+            failure_kind = "unexpected_error"
+            logger.exception("Primary workflow agent.run failed")
         finally:
             await self._drain_workflows()
             self.state.last_updated = datetime.now()
@@ -531,6 +511,23 @@ class PrimaryWorkflowOrchestrator:
                 self.state.active_executions
             )
 
+        completed_this_run = len(self.state.completed_executions) - completed_before
+        elapsed = time.perf_counter() - start_ts
+        if error is not None:
+            return {
+                "success": False,
+                "error": error,
+                "result": {"output": None, "usage": None},
+                "state": self.state,
+                "execution_metadata": {
+                    "workflows_spawned": completed_this_run,
+                    "active_executions": len(self.state.active_executions),
+                    "total_executions": len(self.state.completed_executions),
+                    "elapsed_seconds": elapsed,
+                    "failure_kind": failure_kind,
+                },
+            }
+
         out = getattr(run_result, "output", None)
         usage = getattr(run_result, "usage", None)
         usage_payload: Any = None
@@ -539,13 +536,13 @@ class PrimaryWorkflowOrchestrator:
         elif usage is not None:
             usage_payload = str(usage)
 
-        elapsed = time.perf_counter() - start_ts
         return {
             "success": True,
             "result": {"output": out, "usage": usage_payload},
             "state": self.state,
             "execution_metadata": {
-                "workflows_spawned": len(self.state.active_executions),
+                "workflows_spawned": completed_this_run,
+                "active_executions": len(self.state.active_executions),
                 "total_executions": len(self.state.completed_executions),
                 "elapsed_seconds": elapsed,
             },
@@ -560,6 +557,7 @@ class PrimaryWorkflowOrchestrator:
     ) -> dict[str, Any]:
         """Execute a deterministic workflow composition without LLM tool calls."""
         start_time = time.monotonic()
+        completed_before = len(self.state.completed_executions)
         input_payload = dict(input_data or {})
         workflow_names = self._plan_workflow_names(plan)
         dependency_map = self._plan_dependency_map(plan, workflow_names)
@@ -641,17 +639,18 @@ class PrimaryWorkflowOrchestrator:
         self.state.system_metrics["active_executions"] = len(
             self.state.active_executions
         )
+        plan_results = self.state.completed_executions[completed_before:]
         failed = [
             result
-            for result in self.state.completed_executions
+            for result in plan_results
             if result.status != WorkflowStatus.COMPLETED
         ]
         return {
             "success": not failed,
             "state": self.state,
-            "completed_executions": self.state.completed_executions,
+            "completed_executions": plan_results,
             "execution_metadata": {
-                "total_executions": len(self.state.completed_executions),
+                "total_executions": len(plan_results),
                 "failed_executions": len(failed),
                 "execution_time": time.monotonic() - start_time,
             },

--- a/tests/test_workflow_orchestrator_runtime.py
+++ b/tests/test_workflow_orchestrator_runtime.py
@@ -6,6 +6,8 @@ from typing import Any
 
 import pytest
 from hydra import compose, initialize_config_dir
+from omegaconf import OmegaConf
+from pydantic_ai.exceptions import AgentRunError
 
 from DeepResearch.app import PrimaryREACTWorkflow
 from DeepResearch.src.agents.workflow_orchestrator import (
@@ -233,6 +235,49 @@ async def test_execute_workflow_plan_retries_retryable_adapter_failure(
 
 
 @pytest.mark.asyncio
+async def test_execute_workflow_plan_result_is_scoped_to_current_invocation(
+    no_primary_agent: None,
+) -> None:
+    workflow = WorkflowConfig(
+        workflow_type=WorkflowType.SEARCH_WORKFLOW,
+        name="search",
+        max_retries=0,
+    )
+    orchestrator = make_orchestrator([workflow])
+    calls: list[tuple[str, list[str]]] = []
+    orchestrator.adapter_registry = {
+        WorkflowType.SEARCH_WORKFLOW.value: RecordingAdapter(
+            WorkflowType.SEARCH_WORKFLOW, calls, always_fail=True
+        )
+    }
+
+    first = await orchestrator.execute_workflow_plan(
+        WorkflowPlan(user_input="question", workflow_names=["search"]),
+        {"question": "question"},
+        execution_mode="test",
+    )
+    assert first["success"] is False
+
+    orchestrator.adapter_registry = {
+        WorkflowType.SEARCH_WORKFLOW.value: RecordingAdapter(
+            WorkflowType.SEARCH_WORKFLOW, calls
+        )
+    }
+    second = await orchestrator.execute_workflow_plan(
+        WorkflowPlan(user_input="question", workflow_names=["search"]),
+        {"question": "question"},
+        execution_mode="test",
+    )
+
+    assert second["success"] is True
+    assert second["execution_metadata"]["total_executions"] == 1
+    assert second["execution_metadata"]["failed_executions"] == 0
+    assert len(second["completed_executions"]) == 1
+    assert second["completed_executions"][0].status == WorkflowStatus.COMPLETED
+    assert len(orchestrator.state.completed_executions) == 2
+
+
+@pytest.mark.asyncio
 async def test_execute_workflow_plan_skips_dependents_after_dependency_failure(
     no_primary_agent: None,
 ) -> None:
@@ -354,6 +399,50 @@ async def test_spawned_workflows_are_drained_before_completion(
 
     await orchestrator._drain_workflows()
 
+    assert orchestrator.state.active_executions == []
+    assert len(orchestrator.state.completed_executions) == 1
+    assert orchestrator.state.completed_executions[0].status == WorkflowStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_execute_primary_workflow_failure_metadata_reflects_drained_workflows(
+    no_primary_agent: None,
+) -> None:
+    workflow = WorkflowConfig(
+        workflow_type=WorkflowType.SEARCH_WORKFLOW,
+        name="search",
+        max_retries=0,
+    )
+    orchestrator = make_orchestrator([workflow])
+    calls: list[tuple[str, list[str]]] = []
+    orchestrator.adapter_registry = {
+        WorkflowType.SEARCH_WORKFLOW.value: RecordingAdapter(
+            WorkflowType.SEARCH_WORKFLOW, calls
+        )
+    }
+
+    class FailingPrimaryAgent:
+        async def run(self, *_args: Any, **_kwargs: Any) -> None:
+            orchestrator._spawn_workflow(
+                WorkflowSpawnRequest(
+                    workflow_type=WorkflowType.SEARCH_WORKFLOW,
+                    workflow_name="search",
+                    input_data={"question": "question"},
+                )
+            )
+            raise AgentRunError("model unavailable")
+
+    orchestrator.primary_agent = FailingPrimaryAgent()
+
+    result = await orchestrator.execute_primary_workflow(
+        "question", OmegaConf.create({})
+    )
+
+    assert result["success"] is False
+    assert result["execution_metadata"]["failure_kind"] == "agent_run_error"
+    assert result["execution_metadata"]["workflows_spawned"] == 1
+    assert result["execution_metadata"]["active_executions"] == 0
+    assert result["execution_metadata"]["total_executions"] == 1
     assert orchestrator.state.active_executions == []
     assert len(orchestrator.state.completed_executions) == 1
     assert orchestrator.state.completed_executions[0].status == WorkflowStatus.COMPLETED


### PR DESCRIPTION
## Summary

This is a narrow follow-up for the PRIME workflow orchestration runtime on the `demo` branch, related to #74.

The runtime spine from the earlier issue #74 work is already present on `demo`. This PR does not reimplement that foundation. Instead, it fixes two result-reporting edge cases discovered while auditing the demo-based implementation:

- `execute_workflow_plan(...)` now scopes returned `completed_executions`, `success`, and failure counts to the current invocation instead of using all historical executions stored on the orchestrator.
- `execute_primary_workflow(...)` now reports failure metadata after spawned workflows have been drained, so `workflows_spawned`, `active_executions`, and `total_executions` match the final state returned to callers.

## Why

The orchestrator intentionally keeps cumulative execution state in `self.state.completed_executions`. That is useful for observability, but per-call return values should describe the run that just happened.

Without this fix:

- a failed workflow plan could make a later successful plan report failure on the same orchestrator instance
- a primary-agent failure after spawning workflows could return stale metadata from before the final drain completed

These are correctness issues in the issue #74 runtime-spine layer, but they are small demo-specific hardening changes rather than a new feature slice.

## Changes

- Track the completed-execution count at the start of `execute_primary_workflow(...)` and `execute_workflow_plan(...)`.
- Compute per-invocation completed results from the delta created during the current call.
- Preserve cumulative orchestrator state while returning scoped metadata to callers.
- Add regression tests for:
  - historical failed executions not poisoning a later successful plan result
  - primary workflow failure metadata reflecting drained spawned workflows

## Validation

- `uv run pytest tests/test_workflow_orchestrator_runtime.py -q`
- `uv run pytest tests -q`
- `uv run ruff check DeepResearch/ tests/ --extend-ignore=EXE001,PLR0913,PLR0912,PLR0915,PLR0911`
- `uv run ruff format --check DeepResearch/ tests/`
- `uv run ty check DeepResearch`
- `uv run python -m py_compile DeepResearch/src/agents/workflow_orchestrator.py tests/test_workflow_orchestrator_runtime.py`
- `git diff --check`

All checks passed locally. The full test suite reports existing expected skips and existing pytest warnings unrelated to this diff.

## Notes

This PR targets `demo` and should be reviewed as a small correctness follow-up for #74. It does not reopen or replace the earlier closed runtime-spine PR.
