### PR TITLE
fix(document-processing): stabilize local pipeline engine

### DIFF
--- a/.github/workflows/document-processing-live.yml
+++ b/.github/workflows/document-processing-live.yml
@@ -15,7 +15,7 @@ on:
           - ocr
   pull_request:
     branches:
-      - document-processing
+      - dev
     paths:
       - ".github/workflows/document-processing-live.yml"
       - "DeepResearch/src/document_processing/**"

--- a/.github/workflows/document-processing-live.yml
+++ b/.github/workflows/document-processing-live.yml
@@ -13,6 +13,17 @@ on:
           - docling
           - grobid
           - ocr
+  pull_request:
+    branches:
+      - document-processing
+    paths:
+      - ".github/workflows/document-processing-live.yml"
+      - "DeepResearch/src/document_processing/**"
+      - "configs/document_processing/**"
+      - "docker/document-processing/**"
+      - "tests/test_document_processing/**"
+      - "pyproject.toml"
+      - "uv.lock"
 permissions:
   contents: read
 
@@ -22,7 +33,8 @@ concurrency:
 
 env:
   PYTHON_VERSION: "3.11"
-  TESTED_REVISION: ${{ github.sha }}
+  UV_VERSION: "0.11.29"
+  TESTED_REVISION: ${{ github.event.pull_request.head.sha || github.sha }}
   DOCLING_IMAGE_TAG: quay.io/docling-project/docling-serve-cpu:v1.21.0
   REDIS_IMAGE_TAG: redis:7.2.14-alpine3.21
   GROBID_BASE_IMAGE_TAG: grobid/grobid:0.9.0-full
@@ -42,66 +54,95 @@ env:
 
 jobs:
   quality:
-    name: Configuration, tests, lint, and types
+    name: Tests, static checks, lockfile, and docs
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - name: Check out the tested revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.TESTED_REVISION }}
+
+      - name: Verify the checked-out revision
+        run: |
+          actual_revision="$(git rev-parse HEAD)"
+          test "$actual_revision" = "$TESTED_REVISION"
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install validation dependencies
+      - name: Install uv
         run: |
           python -m pip install --disable-pip-version-check --no-cache-dir \
-            --requirement docker/document-processing/requirements-live.txt \
-            pyyaml==6.0.3 \
-            ruff==0.14.6 \
-            ty==0.0.34
+            "uv==$UV_VERSION"
 
-      - name: Run focused unit and configuration tests
+      - name: Install the locked development environment
+        run: uv sync --group dev --frozen
+
+      - name: Run focused orchestration and pipeline tests
         run: |
-          python -m pytest \
-            tests/test_document_processing/test_clients.py \
-            tests/test_document_processing/test_deployment_config.py \
+          uv run --frozen pytest \
             tests/test_document_processing/test_live_validation_config.py \
             tests/test_document_processing/test_orchestration.py \
             tests/test_document_processing/test_pipeline.py \
             -q -p no:cacheprovider
 
-      - name: Run Ruff lint
+      - name: Run the complete document-processing suite
         run: |
-          ruff check \
-            DeepResearch/src/document_processing \
-            tests/test_document_processing/test_clients.py \
-            tests/test_document_processing/test_deployment_config.py \
-            tests/test_document_processing/test_live_stack_contract.py \
-            tests/test_document_processing/test_live_validation_config.py \
-            tests/test_document_processing/test_orchestration.py \
-            tests/test_document_processing/test_pipeline.py
+          uv run --frozen pytest \
+            tests/test_document_processing \
+            -q -p no:cacheprovider
 
-      - name: Check Ruff formatting
+      - name: Run the repository CI marker selection
         run: |
-          ruff format --check \
-            DeepResearch/src/document_processing \
-            tests/test_document_processing/test_clients.py \
-            tests/test_document_processing/test_deployment_config.py \
-            tests/test_document_processing/test_live_stack_contract.py \
-            tests/test_document_processing/test_live_validation_config.py \
-            tests/test_document_processing/test_orchestration.py \
-            tests/test_document_processing/test_pipeline.py
+          uv run --frozen pytest \
+            tests/ \
+            -m "not optional and not containerized" \
+            --cov=DeepResearch \
+            --cov-report=term-missing \
+            --junitxml=junit.xml \
+            -o junit_family=legacy
 
-      - name: Run document-processing type checks
-        run: ty check DeepResearch/src/document_processing
+      - name: Run the dedicated bioinformatics lane
+        run: |
+          uv run --frozen pytest \
+            tests/test_bioinformatics_tools/ \
+            -m "not containerized" \
+            --cov=DeepResearch \
+            --cov-append \
+            --cov-report=term-missing \
+            --junitxml=junit-bioinformatics.xml \
+            -o junit_family=legacy
+
+      - name: Run full Ruff lint
+        run: |
+          uv run --frozen ruff check \
+            DeepResearch/ tests/ \
+            --extend-ignore=EXE001,PLR0913,PLR0912,PLR0915,PLR0911
+
+      - name: Check full Ruff formatting
+        run: |
+          uv run --frozen ruff format --check DeepResearch/ tests/
+
+      - name: Run full type checks
+        run: uv run --frozen ty check DeepResearch
+
+      - name: Check lockfile and whitespace
+        run: |
+          uv lock --check
+          git diff --check
+
+      - name: Build documentation
+        run: uv run --frozen mkdocs build
 
   docling:
     name: Docling contract (standard runner)
     needs: quality
     if: >-
+      github.event_name == 'pull_request' ||
       inputs.component == 'all' ||
       inputs.component == 'docling'
     runs-on: ubuntu-24.04
@@ -110,6 +151,13 @@ jobs:
     steps:
       - name: Check out the tested revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.TESTED_REVISION }}
+
+      - name: Verify the checked-out revision
+        run: |
+          actual_revision="$(git rev-parse HEAD)"
+          test "$actual_revision" = "$TESTED_REVISION"
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -159,6 +207,13 @@ jobs:
           redis_ref="$(resolve_image "$REDIS_IMAGE_TAG" "$REDIS_IMAGE_DIGEST")"
           docling_digest="${docling_ref##*@}"
           redis_digest="${redis_ref##*@}"
+          docling_image_id="$(
+            docker image inspect "$docling_ref" --format '{{.Id}}'
+          )"
+          if [[ ! "$docling_image_id" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Docling image has no immutable local image ID" >&2
+            exit 1
+          fi
 
           {
             echo "DOCLING_IMAGE_DIGEST=$docling_digest"
@@ -172,6 +227,8 @@ jobs:
             echo "DEEPCRITICAL_LIVE_DOCLING_API_KEY=dc-docling-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
             echo "DEEPCRITICAL_LIVE_GROBID_API_KEY=dc-grobid-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
             echo "REDIS_PASSWORD=dc-redis-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+            echo "DEEPCRITICAL_LIVE_DOCLING_IMAGE_REF=$docling_ref"
+            echo "DEEPCRITICAL_LIVE_DOCLING_IMAGE_ID=$docling_image_id"
           } >> "$GITHUB_ENV"
 
           {
@@ -195,8 +252,16 @@ jobs:
           DEEPCRITICAL_LIVE_TASK_TIMEOUT_SECONDS: "1800"
         run: |
           set -o pipefail
+          docling_container_id="$(
+            docker compose \
+              --file docker/document-processing/compose.yaml \
+              ps --quiet docling-worker
+          )"
+          test -n "$docling_container_id"
+          export DEEPCRITICAL_LIVE_DOCLING_CONTAINER_ID="$docling_container_id"
           python -m pytest \
             tests/test_document_processing/test_live_stack_contract.py::test_live_docling_async_conversion_contract \
+            tests/test_document_processing/test_live_stack_contract.py::test_live_compiled_docling_pipeline \
             -vv --tb=short -p no:cacheprovider \
             2>&1 | tee live-evidence/pytest.txt
 
@@ -228,6 +293,7 @@ jobs:
     name: GROBID contract (standard runner)
     needs: quality
     if: >-
+      github.event_name == 'pull_request' ||
       inputs.component == 'all' ||
       inputs.component == 'grobid'
     runs-on: ubuntu-24.04
@@ -236,6 +302,13 @@ jobs:
     steps:
       - name: Check out the tested revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.TESTED_REVISION }}
+
+      - name: Verify the checked-out revision
+        run: |
+          actual_revision="$(git rev-parse HEAD)"
+          test "$actual_revision" = "$TESTED_REVISION"
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -330,6 +403,10 @@ jobs:
             exit 1
           fi
           echo "GROBID_IMAGE_DIGEST=$grobid_image_id" >> "$GITHUB_ENV"
+          echo "DEEPCRITICAL_LIVE_GROBID_IMAGE_REF=$GROBID_CI_IMAGE_TAG@$grobid_image_id" \
+            >> "$GITHUB_ENV"
+          echo "DEEPCRITICAL_LIVE_GROBID_IMAGE_ID=$grobid_image_id" \
+            >> "$GITHUB_ENV"
           {
             echo "grobid_dockerfile_blob=$grobid_dockerfile_blob"
             echo "grobid_built_image=$GROBID_CI_IMAGE_TAG@$grobid_image_id"
@@ -354,8 +431,17 @@ jobs:
           DEEPCRITICAL_LIVE_REQUEST_TIMEOUT_SECONDS: "900"
         run: |
           set -o pipefail
+          grobid_container_id="$(
+            docker compose \
+              --file docker/document-processing/compose.yaml \
+              --file docker/document-processing/compose.github-actions.yaml \
+              ps --quiet grobid
+          )"
+          test -n "$grobid_container_id"
+          export DEEPCRITICAL_LIVE_GROBID_CONTAINER_ID="$grobid_container_id"
           python -m pytest \
             tests/test_document_processing/test_live_stack_contract.py::test_live_grobid_tei_contract \
+            tests/test_document_processing/test_live_stack_contract.py::test_live_compiled_grobid_pipeline \
             -vv --tb=short -p no:cacheprovider \
             2>&1 | tee live-evidence/pytest.txt
 
@@ -397,6 +483,7 @@ jobs:
     name: OCRmyPDF contract (standard runner)
     needs: quality
     if: >-
+      github.event_name == 'pull_request' ||
       inputs.component == 'all' ||
       inputs.component == 'ocr'
     runs-on: ubuntu-24.04
@@ -405,6 +492,13 @@ jobs:
     steps:
       - name: Check out the tested revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.TESTED_REVISION }}
+
+      - name: Verify the checked-out revision
+        run: |
+          actual_revision="$(git rev-parse HEAD)"
+          test "$actual_revision" = "$TESTED_REVISION"
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -453,6 +547,7 @@ jobs:
           set -o pipefail
           DEEPCRITICAL_LIVE_OCR_IMAGE="$OCR_IMAGE_REF" python -m pytest \
             tests/test_document_processing/test_live_stack_contract.py::test_live_digest_addressed_ocr_derivative_contract \
+            tests/test_document_processing/test_live_stack_contract.py::test_live_compiled_ocr_pipeline \
             -vv --tb=short -p no:cacheprovider \
             2>&1 | tee live-evidence/pytest.txt
 

--- a/DeepResearch/src/document_processing/__init__.py
+++ b/DeepResearch/src/document_processing/__init__.py
@@ -33,6 +33,7 @@ from .clients import (
     ServiceHealth,
 )
 from .document_pipeline import (
+    DocumentProcessingFailureRecorder,
     build_document_component_registry,
     default_document_pipeline_spec,
 )
@@ -100,6 +101,8 @@ from .orchestration import (
     StageDiagnostic,
     StageExecutionStatus,
     StageExecutor,
+    StageFailure,
+    StageFailureObserver,
     StageOutputRef,
     StagePlugin,
     StageResult,
@@ -225,6 +228,7 @@ __all__ = [
     "DoclingServeClient",
     "DocumentArtifact",
     "DocumentProcessingConfig",
+    "DocumentProcessingFailureRecorder",
     "DocumentProcessingResult",
     "DocumentProcessor",
     "DocumentRouter",
@@ -301,6 +305,8 @@ __all__ = [
     "StageDiagnostic",
     "StageExecutionStatus",
     "StageExecutor",
+    "StageFailure",
+    "StageFailureObserver",
     "StageOutputRef",
     "StagePlugin",
     "StageResult",

--- a/DeepResearch/src/document_processing/document_pipeline.py
+++ b/DeepResearch/src/document_processing/document_pipeline.py
@@ -225,6 +225,8 @@ class DocumentProcessingFailureRecorder:
             )
             if run.pipeline_run_id == failure.pipeline_run_id
             and run.started_at >= failure.started_at
+            and run.stage_id == failure.stage_id
+            and run.component == failure.component
         )
         if terminal_during_stage:
             return

--- a/DeepResearch/src/document_processing/document_pipeline.py
+++ b/DeepResearch/src/document_processing/document_pipeline.py
@@ -14,6 +14,7 @@ from .models import (
     DocumentArtifact,
     ProcessingRun,
     ProcessingRunStatus,
+    configuration_sha256,
     sha256_bytes,
 )
 from .orchestration import (
@@ -35,6 +36,7 @@ from .orchestration import (
     StageContext,
     StageExecutionStatus,
     StageExecutor,
+    StageFailure,
     StageOutputRef,
     StageResult,
     StageSpec,
@@ -201,6 +203,47 @@ class _FinalizableFlow:
     integrity: _IntegrityOutcome
     fallback_exhaustion_run: ProcessingRun | None
     stage_runs: tuple[ProcessingRun, ...]
+
+
+class DocumentProcessingFailureRecorder:
+    """Persist unexpected local-stage failures without duplicating domain runs."""
+
+    def __init__(self, processor: DocumentProcessor) -> None:
+        self.processor = processor
+
+    async def record_failure(self, failure: StageFailure) -> None:
+        artifact_id = failure.input_identity.get("artifact_id")
+        if artifact_id is None:
+            raise ValueError(
+                "document-processing failure identity requires artifact_id"
+            )
+        artifact = self.processor.store.get_artifact(artifact_id)
+        terminal_during_stage = tuple(
+            run
+            for run in self.processor.store.list_processing_runs(
+                artifact_id=artifact_id
+            )
+            if run.pipeline_run_id == failure.pipeline_run_id
+            and run.started_at >= failure.started_at
+        )
+        if terminal_during_stage:
+            return
+        configuration = dict(failure.configuration)
+        if configuration_sha256(configuration) != failure.configuration_sha256:
+            raise ValueError(
+                "observed stage configuration does not match its validated hash"
+            )
+        self.processor._save_failed_run(
+            artifact,
+            component_id=failure.component.component_id,
+            component_version=failure.component.component_version,
+            component_descriptor=failure.component,
+            stage_id=failure.stage_id,
+            configuration=configuration,
+            started_at=failure.started_at,
+            started_clock=failure.started_clock,
+            error=failure.exception,
+        )
 
 
 def _port(
@@ -1343,7 +1386,10 @@ def build_document_pipeline(
     return (
         registry,
         compiled,
-        PipelineOrchestrator(executor or LocalStageExecutor()),
+        PipelineOrchestrator(
+            executor or LocalStageExecutor(),
+            failure_observer=DocumentProcessingFailureRecorder(processor),
+        ),
     )
 
 

--- a/DeepResearch/src/document_processing/orchestration.py
+++ b/DeepResearch/src/document_processing/orchestration.py
@@ -8,10 +8,12 @@ The compiler validates the complete graph before an executor sees any input.
 
 from __future__ import annotations
 
+import time
 import uuid
 from collections import defaultdict
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import StrEnum
 from types import MappingProxyType
 from typing import Annotated, Any, Literal, Protocol, TypeAlias
@@ -25,7 +27,12 @@ from pydantic import (
     model_validator,
 )
 
-from .models import ComponentDescriptor, DiagnosticSeverity, configuration_sha256
+from .models import (
+    ComponentDescriptor,
+    DiagnosticSeverity,
+    configuration_sha256,
+    utc_now,
+)
 
 
 class PipelineDefinitionError(ValueError):
@@ -668,7 +675,7 @@ class PipelineCompiler:
                 )
                 if (
                     target.required
-                    and not source_port.required
+                    and _output_may_be_absent(source_stage, source_port)
                     and not _condition_guarantees_output(
                         stage.condition,
                         binding.stage_id,
@@ -677,7 +684,8 @@ class PipelineCompiler:
                 ):
                     raise PipelineDefinitionError(
                         f"required input {stage.stage_id}.{port_name} consumes "
-                        f"conditional output {binding.stage_id}.{binding.output_name} "
+                        f"potentially absent output "
+                        f"{binding.stage_id}.{binding.output_name} "
                         "without an output_present guard"
                     )
 
@@ -862,6 +870,17 @@ def _condition_guarantees_output(
     return matches(condition)
 
 
+def _output_may_be_absent(
+    source_stage: StageSpec,
+    source_port: PortContract,
+) -> bool:
+    """Return whether a declared output can be absent at runtime."""
+
+    return not source_port.required or not isinstance(
+        source_stage.condition, AlwaysCondition
+    )
+
+
 def _topological_order(stages: Sequence[StageSpec]) -> tuple[str, ...]:
     positions = {stage.stage_id: index for index, stage in enumerate(stages)}
     indegree = {stage.stage_id: len(stage.depends_on) for stage in stages}
@@ -899,6 +918,41 @@ class StageExecutor(Protocol):
         stage: CompiledStage,
         context: StageContext,
     ) -> StageResult: ...
+
+
+@dataclass(frozen=True, slots=True)
+class StageFailure:
+    """Typed context for an unexpected component or executor exception."""
+
+    pipeline_id: str
+    pipeline_version: str
+    pipeline_run_id: str
+    stage_id: str
+    component: ComponentDescriptor
+    configuration: Mapping[str, Any]
+    configuration_sha256: str
+    input_identity: Mapping[str, str]
+    exception: Exception
+    started_at: datetime
+    started_clock: float
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "configuration",
+            MappingProxyType(dict(self.configuration)),
+        )
+        object.__setattr__(
+            self,
+            "input_identity",
+            MappingProxyType(dict(self.input_identity)),
+        )
+
+
+class StageFailureObserver(Protocol):
+    """Domain-owned persistence hook for unexpected stage failures."""
+
+    async def record_failure(self, failure: StageFailure) -> None: ...
 
 
 class LocalStageExecutor:
@@ -986,8 +1040,14 @@ class PipelineExecution:
 class PipelineOrchestrator:
     """Evaluate typed conditions and schedule a compiled DAG locally."""
 
-    def __init__(self, executor: StageExecutor | None = None) -> None:
+    def __init__(
+        self,
+        executor: StageExecutor | None = None,
+        *,
+        failure_observer: StageFailureObserver | None = None,
+    ) -> None:
         self.executor = executor or LocalStageExecutor()
+        self.failure_observer = failure_observer
 
     async def execute(
         self,
@@ -995,6 +1055,7 @@ class PipelineOrchestrator:
         inputs: Mapping[str, object],
         *,
         pipeline_run_id: str | None = None,
+        input_identity: Mapping[str, str] | None = None,
     ) -> PipelineExecution:
         try:
             current_specification_sha256 = configuration_sha256(
@@ -1030,6 +1091,22 @@ class PipelineOrchestrator:
                 )
 
         execution_id = pipeline_run_id or f"pipeline-{uuid.uuid4()}"
+        resolved_input_identity = dict(input_identity or {})
+        if self.failure_observer is not None:
+            if not resolved_input_identity:
+                raise PipelineExecutionError(
+                    "input_identity is required when a failure observer is configured"
+                )
+            if any(
+                not isinstance(name, str)
+                or not name.strip()
+                or not isinstance(value, str)
+                or not value.strip()
+                for name, value in resolved_input_identity.items()
+            ):
+                raise PipelineExecutionError(
+                    "input_identity names and values must be non-empty strings"
+                )
         results: dict[str, StageResult] = {}
         for stage in pipeline.stages:
             if not _evaluate_condition(stage.spec.condition, results):
@@ -1060,7 +1137,37 @@ class PipelineOrchestrator:
                 inputs=runtime_inputs,
                 prior_results=results,
             )
-            results[stage.spec.stage_id] = await self.executor.execute(stage, context)
+            started_at = utc_now()
+            started_clock = time.perf_counter()
+            try:
+                results[stage.spec.stage_id] = await self.executor.execute(
+                    stage,
+                    context,
+                )
+            except Exception as exc:
+                if self.failure_observer is not None:
+                    failure = StageFailure(
+                        pipeline_id=pipeline.spec.pipeline_id,
+                        pipeline_version=pipeline.spec.pipeline_version,
+                        pipeline_run_id=execution_id,
+                        stage_id=stage.spec.stage_id,
+                        component=stage.registration.descriptor,
+                        configuration=stage.configuration.model_dump(mode="python"),
+                        configuration_sha256=stage.configuration_sha256,
+                        input_identity=resolved_input_identity,
+                        exception=exc,
+                        started_at=started_at,
+                        started_clock=started_clock,
+                    )
+                    try:
+                        await self.failure_observer.record_failure(failure)
+                    except Exception as observer_error:
+                        exc.add_note(
+                            "the stage failure observer also failed: "
+                            f"{type(observer_error).__name__}: {observer_error}"
+                        )
+                        raise exc from observer_error
+                raise
         return PipelineExecution(pipeline_run_id=execution_id, results=results)
 
 
@@ -1126,6 +1233,8 @@ __all__ = [
     "StageDiagnostic",
     "StageExecutionStatus",
     "StageExecutor",
+    "StageFailure",
+    "StageFailureObserver",
     "StageOutputRef",
     "StagePlugin",
     "StageResult",

--- a/DeepResearch/src/document_processing/pipeline.py
+++ b/DeepResearch/src/document_processing/pipeline.py
@@ -954,6 +954,7 @@ class DocumentProcessor:
             self.compiled_pipeline,
             {"artifact_id": artifact_id},
             pipeline_run_id=context.pipeline_run_id,
+            input_identity={"artifact_id": artifact_id},
         )
         for stage in self.compiled_pipeline.stages:
             result = execution.results[stage.spec.stage_id].outputs.get("result")
@@ -2724,6 +2725,8 @@ class DocumentProcessor:
         started_at: datetime,
         started_clock: float,
         error: Exception,
+        component_descriptor: ComponentDescriptor | None = None,
+        stage_id: str | None = None,
         container_image: str | None = None,
         container_digest: OciDigest | None = None,
         component_versions: dict[str, str] | None = None,
@@ -2738,8 +2741,9 @@ class DocumentProcessor:
         run = ProcessingRun(
             run_id=resolved_run_id,
             artifact_id=artifact.artifact_id,
-            stage_id=component_id,
-            component=_component_descriptor(component_id, component_version),
+            stage_id=stage_id or component_id,
+            component=component_descriptor
+            or _component_descriptor(component_id, component_version),
             runtime_identity_required=runtime_identity_required,
             component_versions=component_versions or {},
             model_versions=model_versions or {},

--- a/docs/adr/0002-allow-listed-local-pipeline.md
+++ b/docs/adr/0002-allow-listed-local-pipeline.md
@@ -37,12 +37,38 @@ unknown condition references, and unsafe consumption of conditional outputs.
 Pipeline conditions use a closed discriminated union; arbitrary code and
 expression evaluation are not supported.
 
+An output is potentially absent when its registered port is optional or its
+producing stage has any condition other than `always`. A required downstream
+input may consume such an output only when its own condition proves that exact
+output is present. For `all`, one conjunct proving presence is sufficient; for
+`any`, every alternative must prove presence. This intentionally conservative
+rule prevents a skipped producer with a nominally required port from creating a
+runtime-only missing-input failure.
+
 `PipelineOrchestrator` schedules the compiled graph through the
 `StageExecutor` protocol. The only implementation in this change is
 `LocalStageExecutor`. The existing document-processing behavior is represented
 by the checked-in YAML graph and runs through these interfaces while preserving
 the existing `ProcessingRun`, `DataProductRef`, diagnostic, recovery, and
 artifact-lineage semantics.
+
+Expected parser and validation failures remain owned by document components:
+the component persists its terminal `ProcessingRun` and returns a typed stage
+result. Unexpected ordinary exceptions are observed by the generic
+orchestrator through an optional `StageFailureObserver`. The observation
+contains pipeline/run identity, stage and registered component identity, the
+validated component configuration and hash, caller-supplied input identity,
+timing, and the original exception. The generic engine does not import
+document storage or document models.
+
+The document-processing implementation supplies
+`DocumentProcessingFailureRecorder`. It checks whether the failing stage
+already persisted a terminal run during that invocation. If so, it does
+nothing; otherwise it persists exactly one failed `ProcessingRun`. Downstream
+stages are not scheduled and the original exception is re-raised. Cancellation
+is outside the ordinary-exception observer path and is re-raised without being
+converted into a failure record. A custom executor may change execution
+mechanics, but the document orchestrator retains this recorder ownership.
 
 ## Consequences
 
@@ -58,4 +84,7 @@ private local values or adding queue-specific nullable fields to
 
 This decision does not introduce the project-owned `CanonicalDocumentView`,
 OCR-correction or study-type components, a queue executor, remote workers, or a
-general-purpose plugin import system.
+general-purpose plugin import system. Those remain separate follow-ups;
+scientific claim extraction, evidence appraisal, Alzheimer’s-specific
+reasoning, hypothesis generation, and experiment design are also outside this
+decision.

--- a/docs/document-processing.md
+++ b/docs/document-processing.md
@@ -89,7 +89,8 @@ validation. Stores containing the old unversioned `records/parser_runs`
 prototype layout are rejected explicitly rather than guessed into the new
 contract.
 
-The default version-2 configuration is in
+The current configuration schema is
+`deepcritical-document-processing-config-v2`, and its default is in
 `configs/document_processing/default.yaml`. Version 2 adds the required
 declarative pipeline graph; version-1 files are rejected instead of being
 silently assigned a graph. In particular, at least 95% of PDF-derived textual
@@ -141,8 +142,11 @@ expression.
 It rejects duplicate stage/component-instance IDs, unknown components,
 unknown or missing inputs, incompatible schema or runtime contracts, cycles,
 invalid component configuration, references outside `depends_on`, and use of
-an optional output as a required input without an explicit
-`output_present` guard. Conditions are a closed typed set (`always`,
+any potentially absent output as a required input without an exact
+`output_present` guard. An output is potentially absent when its registered
+port is optional or its producer has a non-`always` condition. `all` proves
+presence when one conjunct does; `any` proves presence only when every
+alternative does. Conditions are a closed typed set (`always`,
 `output_present`, `output_absent`, `diagnostic_present`, `stage_status`,
 `all`, and `any`); arbitrary expressions are not part of the schema.
 
@@ -156,6 +160,24 @@ the local scientific pipeline is proven. Persisted `ProcessingRun` and
 version-2 output-policy snapshot hashes the complete pipeline specification and
 registry port/configuration contracts, so changing the DAG cannot accidentally
 reuse outputs produced under a different graph.
+
+Expected component failures remain the component’s responsibility: it commits
+its terminal run and returns a typed outcome. The orchestrator reports an
+unexpected ordinary exception through the optional `StageFailureObserver`.
+The document pipeline supplies `DocumentProcessingFailureRecorder`, which
+commits one failed run only when the stage did not already commit a terminal
+run, stops downstream execution, and re-raises the original exception.
+Cancellation is re-raised and is never converted into an ordinary failure.
+The generic orchestration module has no dependency on the content-addressed
+store or document-specific models.
+
+This completes Follow-up 1’s allow-listed local execution layer. Its current
+boundary is intentionally local: several private stage values are ordinary
+in-memory Python objects and are neither durable products nor serializable task
+envelopes. The canonical document view, OCR correction/classification, and
+distributed execution remain separate Follow-ups 2–4. Biomedical extraction,
+evidence appraisal, hypothesis generation, experiment design, and
+Alzheimer’s-specific research functionality remain outside this change.
 
 Process or resume one artifact from the repository root:
 
@@ -265,7 +287,7 @@ defaults are 256 MiB (`services.docling.max_response_bytes`) and 128 MiB
 ceiling becomes an explicit `*_RESPONSE_TOO_LARGE` failed processing run; operators
 may raise the limit in a reviewed deployment override for unusually large papers.
 
-## Opt-in live compatibility contracts
+## Opt-in live compatibility and compiled-pipeline contracts
 
 The normal pytest suite never contacts parser services or starts containers.
 `test_live_stack_contract.py` is marked `document_processing_live` and is
@@ -273,8 +295,27 @@ skipped unless `DEEPCRITICAL_RUN_LIVE_DOCUMENT_PROCESSING=1` is present before
 pytest starts. It generates small synthetic PDFs in memory; no PMC, licensed,
 or benchmark document is uploaded.
 
-With the digest-pinned compose stack already healthy, run the Docling and
-GROBID contracts explicitly:
+The live suite contains two different kinds of checks:
+
+- direct client contracts exercise readiness, version, request, response, and
+  container invocation adapters in isolation;
+- compiled-pipeline smokes instantiate `DocumentProcessor`, compile the
+  checked-in `PipelineSpec`, and traverse the registry, compiler,
+  `PipelineOrchestrator`, and `LocalStageExecutor`.
+
+The free GitHub Actions workflow uses three isolated standard-runner jobs. The
+Docling job runs real Docling on a non-scholarly HTML route and never calls real
+GROBID. The GROBID job uses deterministic fixture-backed Docling output before
+the real GROBID boundary. The OCR job uses deterministic upstream stages that
+force the real digest-addressed OCR branch. Each smoke checks executed and
+skipped stages, a terminal `DocumentProcessingResult`, persisted
+`ProcessingRun` records, `DataProductRef` lineage, the exact pipeline and
+registry snapshot in output-policy provenance, and the service/image identity
+observed by the CI host. These jobs do not constitute an all-real end-to-end
+stack execution.
+
+With the digest-pinned compose stack already healthy, run the direct and
+compiled Docling and GROBID contracts explicitly:
 
 ```bash
 export DEEPCRITICAL_RUN_LIVE_DOCUMENT_PROCESSING=1
@@ -284,7 +325,7 @@ export DEEPCRITICAL_LIVE_GROBID_API_KEY="${GROBID_API_KEY}"
 export DEEPCRITICAL_LIVE_DOCLING_URL="http://127.0.0.1:5001"
 export DEEPCRITICAL_LIVE_GROBID_URL="http://127.0.0.1:8070"
 # Version expectations default to the checked-in pins and may be set explicitly:
-export DEEPCRITICAL_LIVE_EXPECTED_DOCLING_VERSION="2.113.0"
+export DEEPCRITICAL_LIVE_EXPECTED_DOCLING_VERSION="2.96.1"
 export DEEPCRITICAL_LIVE_EXPECTED_DOCLING_SERVE_VERSION="1.21.0"
 export DEEPCRITICAL_LIVE_EXPECTED_GROBID_VERSION="0.9.0"
 
@@ -294,8 +335,11 @@ uv run pytest tests/test_document_processing/test_live_stack_contract.py \
 
 This calls Docling readiness/version endpoints, submits and polls a real async
 conversion, validates the returned serialized `DoclingDocument`, calls GROBID
-alive/version endpoints, and validates a real `processFulltextDocument` TEI
-response. Missing credentials, unreachable services, incompatible response
+alive/version endpoints, validates a real `processFulltextDocument` TEI
+response, and executes the two corresponding compiled-pipeline smokes. The
+compiled tests additionally require the running container IDs and exact image
+references supplied by the workflow’s Docker inspection step. Missing
+credentials, identity evidence, unreachable services, incompatible response
 shapes, and service errors fail the opted-in lane rather than becoming skips.
 
 OCR is a separate opt-in because it requires a local Linux-container runtime
@@ -311,12 +355,14 @@ uv run pytest tests/test_document_processing/test_live_stack_contract.py \
   -m document_processing_live -q
 ```
 
-When requested, the OCR contract fails closed if the runtime or exact
-`image@sha256:...` reference is missing. The runner uses `--pull=never`, probes
-the OCRmyPDF and Tesseract versions inside the pinned image, processes a
-generated raster-only PDF, and validates the searchable derivative and local
-runtime attestation. Until this OCR opt-in passes on the approved Linux target,
-container/OCR compatibility remains an explicit deployment acceptance gate.
+When requested, the direct and compiled OCR contracts fail closed if the
+runtime or exact `image@sha256:...` reference is missing. The runner uses
+`--pull=never`, probes the OCRmyPDF and Tesseract versions inside the pinned
+image, processes a generated raster-only PDF, validates the searchable
+derivative and local runtime attestation, and then repeats that real boundary
+inside the compiled pipeline. Until this OCR opt-in passes on the approved
+Linux target, container/OCR compatibility remains an explicit deployment
+acceptance gate.
 
 These are compatibility contracts, not the 50–75-document quality bake-off;
 they do not replace corpus accuracy, resource-accounting, or task-bound service

--- a/tests/test_document_processing/test_live_stack_contract.py
+++ b/tests/test_document_processing/test_live_stack_contract.py
@@ -11,10 +11,12 @@ import io
 import os
 import re
 import shutil
+import subprocess
 import zlib
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import pytest
 import yaml
@@ -23,9 +25,31 @@ from pypdf import PdfReader
 
 from DeepResearch.src.document_processing.clients import (
     ContainerOCRmyPDFRunner,
+    DoclingConversionResult,
     DoclingServeClient,
     GrobidClient,
+    GrobidResult,
+    OCRResult,
 )
+from DeepResearch.src.document_processing.models import (
+    ProcessingRun,
+    ProcessingRunStatus,
+    RuntimeAttestation,
+    RuntimeAttestationSource,
+    utc_now,
+)
+from DeepResearch.src.document_processing.orchestration import (
+    CompiledStage,
+    LocalStageExecutor,
+    StageContext,
+    StageResult,
+)
+from DeepResearch.src.document_processing.pipeline import (
+    DocumentProcessingConfig,
+    DocumentProcessingResult,
+    DocumentProcessor,
+)
+from DeepResearch.src.document_processing.storage import ContentAddressedStore
 
 _LIVE_ENABLED = os.getenv("DEEPCRITICAL_RUN_LIVE_DOCUMENT_PROCESSING") == "1"
 _LIVE_OCR_ENABLED = os.getenv("DEEPCRITICAL_RUN_LIVE_DOCUMENT_PROCESSING_OCR") == "1"
@@ -127,6 +151,242 @@ def live_stack_config() -> _LiveStackConfig:
             _configured_service_version("grobid", "component_version"),
         ).strip(),
     )
+
+
+@dataclass(frozen=True, slots=True)
+class _DockerRuntimeReporter:
+    """Bind one parser invocation to the container inspected by the CI host."""
+
+    expected_reporter_id: str
+    component_id: str
+    component_version: str
+    component_versions: Mapping[str, str]
+    container_reference: str
+    container_id: str
+    expected_image_id: str
+
+    async def resolve(
+        self,
+        *,
+        component_id: str,
+        remote_task_id: str | None,
+    ) -> RuntimeAttestation:
+        if component_id != self.component_id:
+            raise ValueError("runtime reporter component does not match")
+        if remote_task_id is None or not remote_task_id.strip():
+            raise ValueError("runtime reporter requires an invocation identity")
+        if not _DIGEST_ADDRESSED_IMAGE.fullmatch(self.container_reference):
+            raise ValueError("runtime reporter requires an immutable image reference")
+        inspected = subprocess.run(
+            [
+                "docker",
+                "inspect",
+                "--format",
+                "{{.Image}}",
+                self.container_id,
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        if inspected != self.expected_image_id:
+            raise ValueError(
+                "running parser container does not use the expected image ID"
+            )
+        return RuntimeAttestation(
+            component_id=component_id,
+            component_version=self.component_version,
+            invocation_id=remote_task_id,
+            source=RuntimeAttestationSource.AUTHENTICATED_DEPLOYMENT_REPORTER,
+            reporter_id=self.expected_reporter_id,
+            observed_at=utc_now(),
+            workload_id=self.container_id,
+            container_reference=self.container_reference,
+            container_digest=self.container_reference.rsplit("@", maxsplit=1)[1],
+            container_image_id=inspected,
+            component_versions=dict(self.component_versions),
+        )
+
+
+class _RecordingExecutor:
+    def __init__(self) -> None:
+        self.stage_ids: list[str] = []
+        self.local = LocalStageExecutor()
+
+    async def execute(
+        self,
+        stage: CompiledStage,
+        context: StageContext,
+    ) -> StageResult:
+        self.stage_ids.append(stage.spec.stage_id)
+        return await self.local.execute(stage, context)
+
+
+def _fixture_docling_document(*, image_only: bool = False) -> dict[str, Any]:
+    text = (
+        "x"
+        if image_only
+        else "This deterministic upstream document reports reproducible evidence."
+    )
+    return {
+        "schema_name": "DoclingDocument",
+        "version": "1.0.0",
+        "name": "live-pipeline-fixture",
+        "body": {
+            "self_ref": "#/body",
+            "children": [{"$ref": "#/texts/0"}],
+        },
+        "furniture": {"self_ref": "#/furniture", "children": []},
+        "groups": [],
+        "texts": [
+            {
+                "self_ref": "#/texts/0",
+                "label": "paragraph",
+                "text": text,
+                "prov": [
+                    {
+                        "page_no": 1,
+                        "bbox": {
+                            "l": 10,
+                            "t": 40,
+                            "r": 180,
+                            "b": 20,
+                            "coord_origin": "BOTTOMLEFT",
+                        },
+                    }
+                ],
+            }
+        ],
+        "tables": [],
+        "pictures": [],
+        "key_value_items": [],
+        "pages": {"1": {"page_no": 1}},
+    }
+
+
+class _FixtureDocling:
+    def __init__(self, *, image_only: bool = False) -> None:
+        self.image_only = image_only
+        self.calls = 0
+
+    async def convert(self, *args: Any, **kwargs: Any) -> DoclingConversionResult:
+        self.calls += 1
+        document = _fixture_docling_document(image_only=self.image_only)
+        raw = {
+            "document": {"json_content": document},
+            "status": "success",
+            "processing_time": 0.01,
+            "timings": {},
+            "errors": [],
+        }
+        return DoclingConversionResult(
+            document=document,
+            raw_response=raw,
+            status="success",
+            processing_time_seconds=0.01,
+            remote_task_id=f"fixture-docling-{self.calls}",
+        )
+
+
+class _FixtureGrobid:
+    coordinates = GrobidClient.DEFAULT_COORDINATES
+    consolidate_header = 0
+    consolidate_citations = 0
+    segment_sentences = True
+
+    def __init__(self, *, force_ocr: bool = False) -> None:
+        self.force_ocr = force_ocr
+        self.calls = 0
+
+    async def process_fulltext(
+        self,
+        content: bytes,
+        *,
+        filename: str,
+    ) -> GrobidResult:
+        self.calls += 1
+        if self.force_ocr and self.calls == 1:
+            tei = b'<TEI xmlns="http://www.tei-c.org/ns/1.0"><text/></TEI>'
+        else:
+            tei = b"""<TEI xmlns="http://www.tei-c.org/ns/1.0"><text><body><div>
+            <head coords="1,10,10,80,10">Results</head>
+            <p coords="1,10,30,80,10">Deterministic fixture evidence remains usable
+            after the real OCR boundary and supports compiled-pipeline validation.</p>
+            </div></body></text></TEI>"""
+        return GrobidResult(
+            tei_xml=tei,
+            coordinates=self.coordinates,
+            status_code=200,
+            remote_request_id=f"fixture-grobid-{self.calls}",
+        )
+
+
+class _NeverGrobid(_FixtureGrobid):
+    async def process_fulltext(
+        self,
+        content: bytes,
+        *,
+        filename: str,
+    ) -> GrobidResult:
+        raise AssertionError("GROBID must not run in the Docling-only smoke")
+
+
+class _NeverOCR:
+    languages = ("eng",)
+    rotate_pages = True
+    deskew = True
+    jobs = 1
+    optimize = 1
+
+    async def convert(self, content: bytes) -> OCRResult:
+        raise AssertionError("OCR must not run in this compiled-pipeline smoke")
+
+
+def _assert_compiled_pipeline_result(
+    *,
+    processor: DocumentProcessor,
+    store: ContentAddressedStore,
+    result: DocumentProcessingResult,
+    executor: _RecordingExecutor,
+    skipped_stages: set[str],
+) -> None:
+    stage_ids = [stage.spec.stage_id for stage in processor.compiled_pipeline.stages]
+    assert executor.stage_ids == [
+        stage_id for stage_id in stage_ids if stage_id not in skipped_stages
+    ]
+    assert set(stage_ids) - set(executor.stage_ids) == skipped_stages
+    assert result.status in {
+        ProcessingRunStatus.COMPLETE,
+        ProcessingRunStatus.PARTIAL,
+    }
+    assert result.processing_runs
+    expected_specification = processor.pipeline_spec.model_dump(
+        mode="json",
+        by_alias=True,
+    )
+    expected_registry = processor.component_registry.contract_snapshot()
+    for run in result.processing_runs:
+        assert store.get_processing_run(run.run_id) == run
+        policy = run.output_policy_snapshot
+        assert policy["schema"] == "deepcritical-document-output-policy-v2"
+        assert policy["local_pipeline"]["specification"] == expected_specification
+        assert policy["local_pipeline"]["registry"] == expected_registry
+        for product in run.outputs:
+            assert product.producer_run_id == run.run_id
+            assert run.artifact_id in product.source_artifact_ids
+            store.verify_blob(product.blob_sha256)
+        for product in run.inputs:
+            producer = store.get_processing_run(product.producer_run_id)
+            assert product in producer.outputs
+
+
+def _run_for_component(
+    runs: tuple[ProcessingRun, ...],
+    component_id: str,
+) -> ProcessingRun:
+    selected = tuple(run for run in runs if run.component_id == component_id)
+    assert len(selected) == 1
+    return selected[0]
 
 
 def _assemble_pdf(objects: list[bytes]) -> bytes:
@@ -371,3 +631,234 @@ async def test_live_digest_addressed_ocr_derivative_contract(
         "17.4.1"
     )
     assert result.runtime_attestation.component_versions["tesseract"]
+
+
+@pytest.mark.asyncio
+async def test_live_compiled_docling_pipeline(
+    live_stack_config: _LiveStackConfig,
+    tmp_path: Path,
+) -> None:
+    base_client = DoclingServeClient(
+        live_stack_config.docling_url,
+        api_key=live_stack_config.docling_api_key,
+        connect_timeout_seconds=live_stack_config.connect_timeout_seconds,
+        request_timeout_seconds=live_stack_config.request_timeout_seconds,
+        task_timeout_seconds=live_stack_config.task_timeout_seconds,
+        poll_interval_seconds=0.5,
+        use_async_api=True,
+    )
+    versions = await base_client.version()
+    image_reference = _required_environment("DEEPCRITICAL_LIVE_DOCLING_IMAGE_REF")
+    reporter = _DockerRuntimeReporter(
+        expected_reporter_id="github-actions-docker-inspector",
+        component_id="docling",
+        component_version=versions["docling"],
+        component_versions=versions,
+        container_reference=image_reference,
+        container_id=_required_environment("DEEPCRITICAL_LIVE_DOCLING_CONTAINER_ID"),
+        expected_image_id=_required_environment("DEEPCRITICAL_LIVE_DOCLING_IMAGE_ID"),
+    )
+    client = DoclingServeClient(
+        live_stack_config.docling_url,
+        api_key=live_stack_config.docling_api_key,
+        connect_timeout_seconds=live_stack_config.connect_timeout_seconds,
+        request_timeout_seconds=live_stack_config.request_timeout_seconds,
+        task_timeout_seconds=live_stack_config.task_timeout_seconds,
+        poll_interval_seconds=0.5,
+        use_async_api=True,
+        runtime_reporter=reporter,
+    )
+    executor = _RecordingExecutor()
+    store = ContentAddressedStore(tmp_path / "docling-store")
+    processor = DocumentProcessor(
+        store,
+        docling=client,
+        grobid=_NeverGrobid(),
+        ocrmypdf=_NeverOCR(),
+        config=DocumentProcessingConfig(
+            docling_version=live_stack_config.expected_docling_version,
+            docling_serve_version=live_stack_config.expected_docling_serve_version,
+            docling_container_image=image_reference.split("@", maxsplit=1)[0],
+            docling_container_digest=image_reference.rsplit("@", maxsplit=1)[1],
+            docling_options={"do_ocr": False},
+            grobid_enabled=False,
+            ocr_enabled=False,
+            preflight_enabled=False,
+            require_runtime_identity=False,
+        ),
+        stage_executor=executor,
+    )
+    artifact = processor.ingest_bytes(
+        b"<html><body><h1>Methods</h1><p>Compiled Docling smoke.</p></body></html>",
+        acquisition_uri="https://example.test/live-docling.html",
+        media_type="text/html",
+        identifiers={"filename": "live-docling.html"},
+    )
+
+    result = await processor.process_artifact(artifact.artifact_id)
+
+    _assert_compiled_pipeline_result(
+        processor=processor,
+        store=store,
+        result=result,
+        executor=executor,
+        skipped_stages={
+            "primary-grobid",
+            "ocr",
+            "fallback-grobid",
+            "alignment",
+        },
+    )
+    run = _run_for_component(result.processing_runs, "docling")
+    assert run.runtime_attestation is not None
+    assert run.runtime_attestation.container_reference == image_reference
+    assert run.runtime_attestation.container_image_id == reporter.expected_image_id
+    assert run.component_versions == versions
+
+
+@pytest.mark.asyncio
+async def test_live_compiled_grobid_pipeline(
+    live_stack_config: _LiveStackConfig,
+    synthetic_scholarly_pdf: bytes,
+    tmp_path: Path,
+) -> None:
+    base_client = GrobidClient(
+        live_stack_config.grobid_url,
+        api_key=live_stack_config.grobid_api_key,
+        connect_timeout_seconds=live_stack_config.connect_timeout_seconds,
+        timeout_seconds=live_stack_config.request_timeout_seconds,
+    )
+    version = await base_client.version()
+    image_reference = _required_environment("DEEPCRITICAL_LIVE_GROBID_IMAGE_REF")
+    reporter = _DockerRuntimeReporter(
+        expected_reporter_id="github-actions-docker-inspector",
+        component_id="grobid",
+        component_version=version,
+        component_versions={"grobid": version},
+        container_reference=image_reference,
+        container_id=_required_environment("DEEPCRITICAL_LIVE_GROBID_CONTAINER_ID"),
+        expected_image_id=_required_environment("DEEPCRITICAL_LIVE_GROBID_IMAGE_ID"),
+    )
+    client = GrobidClient(
+        live_stack_config.grobid_url,
+        api_key=live_stack_config.grobid_api_key,
+        connect_timeout_seconds=live_stack_config.connect_timeout_seconds,
+        timeout_seconds=live_stack_config.request_timeout_seconds,
+        runtime_reporter=reporter,
+    )
+    executor = _RecordingExecutor()
+    store = ContentAddressedStore(tmp_path / "grobid-store")
+    processor = DocumentProcessor(
+        store,
+        docling=_FixtureDocling(),
+        grobid=client,
+        ocrmypdf=_NeverOCR(),
+        config=DocumentProcessingConfig(
+            docling_version="fixture-docling-v1",
+            grobid_version=version,
+            grobid_container_image=image_reference.split("@", maxsplit=1)[0],
+            grobid_container_digest=image_reference.rsplit("@", maxsplit=1)[1],
+            grobid_minimum_text_characters=0,
+            ocr_enabled=False,
+            preflight_enabled=False,
+            require_runtime_identity=False,
+        ),
+        stage_executor=executor,
+    )
+    artifact = processor.ingest_bytes(
+        synthetic_scholarly_pdf,
+        acquisition_uri="https://example.test/live-grobid.pdf",
+        media_type="application/pdf",
+        identifiers={"filename": "live-grobid.pdf"},
+    )
+
+    result = await processor.process_artifact(artifact.artifact_id)
+
+    _assert_compiled_pipeline_result(
+        processor=processor,
+        store=store,
+        result=result,
+        executor=executor,
+        skipped_stages={"ocr", "fallback-grobid"},
+    )
+    run = _run_for_component(result.processing_runs, "grobid")
+    assert run.runtime_attestation is not None
+    assert run.runtime_attestation.container_reference == image_reference
+    assert run.runtime_attestation.container_image_id == reporter.expected_image_id
+    assert run.component_versions == {"grobid": version}
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not _LIVE_OCR_ENABLED,
+    reason=(
+        "set DEEPCRITICAL_RUN_LIVE_DOCUMENT_PROCESSING_OCR=1 to run the "
+        "compiled digest-addressed OCR pipeline"
+    ),
+)
+async def test_live_compiled_ocr_pipeline(
+    synthetic_image_only_pdf: bytes,
+    tmp_path: Path,
+) -> None:
+    image_reference = _required_environment("DEEPCRITICAL_LIVE_OCR_IMAGE")
+    digest = image_reference.rsplit("@", maxsplit=1)[1]
+    runner = ContainerOCRmyPDFRunner(
+        image_reference,
+        runtime_executable=os.getenv(
+            "DEEPCRITICAL_LIVE_CONTAINER_RUNTIME",
+            "docker",
+        ).strip(),
+        timeout_seconds=_positive_environment_float(
+            "DEEPCRITICAL_LIVE_OCR_TIMEOUT_SECONDS",
+            600.0,
+        ),
+        probe_timeout_seconds=_positive_environment_float(
+            "DEEPCRITICAL_LIVE_OCR_PROBE_TIMEOUT_SECONDS",
+            60.0,
+        ),
+        jobs=1,
+        require_digest_addressed=True,
+    )
+    grobid = _FixtureGrobid(force_ocr=True)
+    executor = _RecordingExecutor()
+    store = ContentAddressedStore(tmp_path / "ocr-store")
+    processor = DocumentProcessor(
+        store,
+        docling=_FixtureDocling(image_only=True),
+        grobid=grobid,
+        ocrmypdf=runner,
+        config=DocumentProcessingConfig(
+            docling_version="fixture-docling-v1",
+            grobid_version="fixture-grobid-v1",
+            grobid_minimum_text_characters=80,
+            ocrmypdf_version="17.4.1",
+            ocr_mode="container_cli",
+            ocr_container_image=image_reference.split("@", maxsplit=1)[0],
+            ocr_container_digest=digest,
+            preflight_enabled=False,
+            require_runtime_identity=True,
+        ),
+        stage_executor=executor,
+    )
+    artifact = processor.ingest_bytes(
+        synthetic_image_only_pdf,
+        acquisition_uri="https://example.test/live-ocr.pdf",
+        media_type="application/pdf",
+        identifiers={"filename": "live-ocr.pdf"},
+    )
+
+    result = await processor.process_artifact(artifact.artifact_id)
+
+    _assert_compiled_pipeline_result(
+        processor=processor,
+        store=store,
+        result=result,
+        executor=executor,
+        skipped_stages=set(),
+    )
+    assert grobid.calls == 2
+    run = _run_for_component(result.processing_runs, "ocrmypdf")
+    assert run.runtime_attestation is not None
+    assert run.runtime_attestation.container_reference == image_reference
+    assert run.runtime_attestation.container_digest == digest
+    assert run.component_versions["ocrmypdf"] == "17.4.1"

--- a/tests/test_document_processing/test_live_validation_config.py
+++ b/tests/test_document_processing/test_live_validation_config.py
@@ -179,7 +179,7 @@ def test_hardening_pull_requests_run_every_isolated_live_job() -> None:
         Loader=yaml.BaseLoader,
     )
     pull_request = workflow["on"]["pull_request"]
-    assert pull_request["branches"] == ["document-processing"]
+    assert pull_request["branches"] == ["dev"]
     assert set(pull_request["paths"]) == {
         ".github/workflows/document-processing-live.yml",
         "DeepResearch/src/document_processing/**",

--- a/tests/test_document_processing/test_live_validation_config.py
+++ b/tests/test_document_processing/test_live_validation_config.py
@@ -10,6 +10,22 @@ def _repository_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
+def _live_workflow_path() -> Path:
+    return _repository_root() / ".github" / "workflows" / "document-processing-live.yml"
+
+
+def _live_workflow() -> dict:
+    return yaml.safe_load(_live_workflow_path().read_text(encoding="utf-8"))
+
+
+def _step(jobs: dict, job_name: str, step_name: str) -> dict:
+    selected = tuple(
+        step for step in jobs[job_name]["steps"] if step.get("name") == step_name
+    )
+    assert len(selected) == 1
+    return selected[0]
+
+
 def test_live_requirements_match_the_repository_lock() -> None:
     root = _repository_root()
     requirement_lines = (
@@ -100,3 +116,152 @@ def test_live_policy_versions_match_the_pinned_stack() -> None:
     assert services["grobid"]["component_version"] == "0.9.0"
     assert services["ocr"]["container_image"] == "jbarlow83/ocrmypdf:v17.4.1"
     assert services["ocr"]["component_version"] == "17.4.1"
+
+
+def test_live_workflow_runs_direct_and_compiled_contracts_in_isolated_jobs() -> None:
+    workflow = _live_workflow()
+    jobs = workflow["jobs"]
+
+    assert set(jobs) == {"quality", "docling", "grobid", "ocr"}
+    assert all(job["runs-on"] == "ubuntu-24.04" for job in jobs.values())
+    assert "continue-on-error" not in _live_workflow_path().read_text(encoding="utf-8")
+
+    selections = {
+        "docling": (
+            "test_live_docling_async_conversion_contract",
+            "test_live_compiled_docling_pipeline",
+        ),
+        "grobid": (
+            "test_live_grobid_tei_contract",
+            "test_live_compiled_grobid_pipeline",
+        ),
+        "ocr": (
+            "test_live_digest_addressed_ocr_derivative_contract",
+            "test_live_compiled_ocr_pipeline",
+        ),
+    }
+    for job_name, test_names in selections.items():
+        run_step = next(
+            step
+            for step in jobs[job_name]["steps"]
+            if step.get("name", "").startswith("Run the ")
+        )
+        command = run_step["run"]
+        assert all(test_name in command for test_name in test_names)
+
+
+def test_every_live_job_verifies_the_reported_checkout_revision() -> None:
+    workflow = _live_workflow()
+    assert (
+        workflow["env"]["TESTED_REVISION"]
+        == "${{ github.event.pull_request.head.sha || github.sha }}"
+    )
+
+    for job_name in ("quality", "docling", "grobid", "ocr"):
+        checkout = _step(
+            workflow["jobs"],
+            job_name,
+            "Check out the tested revision",
+        )
+        assert checkout["with"]["ref"] == "${{ env.TESTED_REVISION }}"
+        verify = _step(
+            workflow["jobs"],
+            job_name,
+            "Verify the checked-out revision",
+        )
+        assert 'actual_revision="$(git rev-parse HEAD)"' in verify["run"]
+        assert 'test "$actual_revision" = "$TESTED_REVISION"' in verify["run"]
+
+
+def test_hardening_pull_requests_run_every_isolated_live_job() -> None:
+    workflow = yaml.load(
+        _live_workflow_path().read_text(encoding="utf-8"),
+        Loader=yaml.BaseLoader,
+    )
+    pull_request = workflow["on"]["pull_request"]
+    assert pull_request["branches"] == ["document-processing"]
+    assert set(pull_request["paths"]) == {
+        ".github/workflows/document-processing-live.yml",
+        "DeepResearch/src/document_processing/**",
+        "configs/document_processing/**",
+        "docker/document-processing/**",
+        "tests/test_document_processing/**",
+        "pyproject.toml",
+        "uv.lock",
+    }
+
+    for job_name in ("docling", "grobid", "ocr"):
+        assert "github.event_name == 'pull_request'" in workflow["jobs"][job_name]["if"]
+
+
+def test_quality_job_enforces_the_complete_repository_gate() -> None:
+    jobs = _live_workflow()["jobs"]
+    quality = jobs["quality"]
+    assert quality["timeout-minutes"] == 30
+    assert all(
+        jobs[name]["needs"] == "quality" for name in ("docling", "grobid", "ocr")
+    )
+
+    document_suite = _step(
+        jobs,
+        "quality",
+        "Run the complete document-processing suite",
+    )["run"]
+    assert "tests/test_document_processing" in document_suite
+
+    repository_suite = _step(
+        jobs,
+        "quality",
+        "Run the repository CI marker selection",
+    )["run"]
+    assert '-m "not optional and not containerized"' in repository_suite
+    assert "--ignore" not in repository_suite
+    assert "--deselect" not in repository_suite
+
+    assert (
+        "tests/test_bioinformatics_tools/"
+        in _step(
+            jobs,
+            "quality",
+            "Run the dedicated bioinformatics lane",
+        )["run"]
+    )
+    assert (
+        "DeepResearch/ tests/"
+        in _step(
+            jobs,
+            "quality",
+            "Run full Ruff lint",
+        )["run"]
+    )
+    assert (
+        "ruff format --check DeepResearch/ tests/"
+        in _step(
+            jobs,
+            "quality",
+            "Check full Ruff formatting",
+        )["run"]
+    )
+    assert (
+        "ty check DeepResearch"
+        in _step(
+            jobs,
+            "quality",
+            "Run full type checks",
+        )["run"]
+    )
+    lock_and_whitespace = _step(
+        jobs,
+        "quality",
+        "Check lockfile and whitespace",
+    )["run"]
+    assert "uv lock --check" in lock_and_whitespace
+    assert "git diff --check" in lock_and_whitespace
+    assert (
+        "mkdocs build"
+        in _step(
+            jobs,
+            "quality",
+            "Build documentation",
+        )["run"]
+    )

--- a/tests/test_document_processing/test_orchestration.py
+++ b/tests/test_document_processing/test_orchestration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -12,8 +13,13 @@ from DeepResearch.src.document_processing import (
     ComponentDescriptor,
     default_document_pipeline_spec,
 )
-from DeepResearch.src.document_processing.models import DiagnosticSeverity
+from DeepResearch.src.document_processing.models import (
+    DiagnosticSeverity,
+    configuration_sha256,
+)
 from DeepResearch.src.document_processing.orchestration import (
+    AllCondition,
+    AnyCondition,
     ComponentInstanceSpec,
     ComponentRegistration,
     ComponentRegistry,
@@ -33,9 +39,11 @@ from DeepResearch.src.document_processing.orchestration import (
     StageContext,
     StageDiagnostic,
     StageExecutionStatus,
+    StageFailure,
     StageOutputRef,
     StageResult,
     StageSpec,
+    StageStatusCondition,
 )
 
 TEXT = PortContract(
@@ -65,6 +73,14 @@ class PrefixConfig(BaseModel):
 @dataclass(frozen=True, slots=True)
 class _CallLog:
     stage_ids: list[str]
+
+
+class _RecordingFailureObserver:
+    def __init__(self) -> None:
+        self.failures: list[StageFailure] = []
+
+    async def record_failure(self, failure: StageFailure) -> None:
+        self.failures.append(failure)
 
 
 def _registration(
@@ -500,8 +516,221 @@ def test_compiler_rejects_cycles_missing_inputs_and_incompatible_schemas() -> No
         PipelineCompiler(registry).compile(incompatible)
 
 
+def _conditional_required_output_graph(
+    *,
+    consumer_condition: Any | None = None,
+    optional_consumer_input: bool = False,
+) -> tuple[ComponentRegistry, PipelineSpec]:
+    async def gate(_: StageContext, __: BaseModel) -> StageResult:
+        return StageResult(status=StageExecutionStatus.FAILED)
+
+    async def produce(context: StageContext, _: BaseModel) -> StageResult:
+        return StageResult(
+            status=StageExecutionStatus.COMPLETE,
+            outputs={"text": context.require_input("text", str)},
+        )
+
+    async def consume(context: StageContext, _: BaseModel) -> StageResult:
+        return StageResult(
+            status=StageExecutionStatus.COMPLETE,
+            outputs={"result": context.inputs.get("text", "missing")},
+        )
+
+    registry = ComponentRegistry()
+    registry.register(
+        _registration(
+            "gate",
+            input_ports={"text": TEXT},
+            output_ports={"text": TEXT},
+            handler=gate,
+        )
+    )
+    registry.register(
+        _registration(
+            "produce",
+            input_ports={"text": TEXT},
+            output_ports={"text": TEXT},
+            handler=produce,
+        )
+    )
+    registry.register(
+        _registration(
+            "consume",
+            input_ports={
+                "text": OPTIONAL_TEXT if optional_consumer_input else TEXT,
+            },
+            output_ports={"result": TEXT},
+            handler=consume,
+        )
+    )
+    components = (
+        ComponentInstanceSpec(instance_id="gate", component_id="gate"),
+        ComponentInstanceSpec(instance_id="produce", component_id="produce"),
+        ComponentInstanceSpec(instance_id="consume", component_id="consume"),
+    )
+    consumer_updates: dict[str, Any] = {}
+    if consumer_condition is not None:
+        consumer_updates["condition"] = consumer_condition
+    return registry, _pipeline(
+        components=components,
+        stages=(
+            StageSpec(
+                stage_id="gate",
+                component="gate",
+                inputs={"text": PipelineInputRef(input_name="text")},
+                outputs=("text",),
+            ),
+            StageSpec(
+                stage_id="produce",
+                component="produce",
+                depends_on=("gate",),
+                inputs={
+                    "text": StageOutputRef(
+                        stage_id="gate",
+                        output_name="text",
+                    )
+                },
+                outputs=("text",),
+                condition=OutputPresentCondition(
+                    stage_id="gate",
+                    output_name="text",
+                ),
+            ),
+            StageSpec(
+                stage_id="consume",
+                component="consume",
+                depends_on=("gate", "produce"),
+                inputs={
+                    "text": StageOutputRef(
+                        stage_id="produce",
+                        output_name="text",
+                    )
+                },
+                outputs=("result",),
+                **consumer_updates,
+            ),
+        ),
+    )
+
+
+def test_conditional_producer_required_output_needs_exact_presence_guard() -> None:
+    registry, unguarded = _conditional_required_output_graph()
+
+    with pytest.raises(
+        PipelineDefinitionError,
+        match=r"potentially absent output produce\.text.*output_present guard",
+    ):
+        PipelineCompiler(registry).compile(unguarded)
+
+
 @pytest.mark.asyncio
-async def test_conditional_output_requires_and_honors_typed_presence_guard() -> None:
+async def test_conditional_producer_guard_compiles_and_skips_safely() -> None:
+    registry, guarded = _conditional_required_output_graph(
+        consumer_condition=OutputPresentCondition(
+            stage_id="produce",
+            output_name="text",
+        )
+    )
+
+    execution = await PipelineOrchestrator().execute(
+        PipelineCompiler(registry).compile(guarded),
+        {"text": "input"},
+    )
+
+    assert execution.result_for("gate").status is StageExecutionStatus.FAILED
+    assert execution.result_for("produce").status is StageExecutionStatus.SKIPPED
+    assert execution.result_for("consume").status is StageExecutionStatus.SKIPPED
+
+
+def test_unconditional_required_producer_remains_compatible() -> None:
+    async def passthrough(context: StageContext, _: BaseModel) -> StageResult:
+        return StageResult(
+            status=StageExecutionStatus.COMPLETE,
+            outputs={"text": context.require_input("text", str)},
+        )
+
+    registry = ComponentRegistry()
+    registry.register(
+        _registration(
+            "passthrough",
+            input_ports={"text": TEXT},
+            output_ports={"text": TEXT},
+            handler=passthrough,
+        )
+    )
+    PipelineCompiler(registry).compile(
+        _pipeline(
+            components=(
+                ComponentInstanceSpec(
+                    instance_id="passthrough",
+                    component_id="passthrough",
+                ),
+            ),
+            stages=(
+                StageSpec(
+                    stage_id="first",
+                    component="passthrough",
+                    inputs={"text": PipelineInputRef(input_name="text")},
+                    outputs=("text",),
+                ),
+                StageSpec(
+                    stage_id="second",
+                    component="passthrough",
+                    depends_on=("first",),
+                    inputs={
+                        "text": StageOutputRef(
+                            stage_id="first",
+                            output_name="text",
+                        )
+                    },
+                    outputs=("text",),
+                ),
+            ),
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_optional_consumer_input_does_not_need_presence_guard() -> None:
+    registry, optional_input = _conditional_required_output_graph(
+        optional_consumer_input=True
+    )
+
+    execution = await PipelineOrchestrator().execute(
+        PipelineCompiler(registry).compile(optional_input),
+        {"text": "input"},
+    )
+
+    assert execution.result_for("produce").status is StageExecutionStatus.SKIPPED
+    assert execution.result_for("consume").outputs["result"] == "missing"
+
+
+def test_all_and_any_presence_proofs_are_conservative() -> None:
+    present = OutputPresentCondition(stage_id="produce", output_name="text")
+    gate_failed = StageStatusCondition(
+        stage_id="gate",
+        statuses=(StageExecutionStatus.FAILED,),
+    )
+
+    registry, all_guarded = _conditional_required_output_graph(
+        consumer_condition=AllCondition(conditions=(present, gate_failed))
+    )
+    PipelineCompiler(registry).compile(all_guarded)
+
+    registry, any_unguarded = _conditional_required_output_graph(
+        consumer_condition=AnyCondition(conditions=(present, gate_failed))
+    )
+    with pytest.raises(PipelineDefinitionError, match="output_present guard"):
+        PipelineCompiler(registry).compile(any_unguarded)
+
+    registry, any_exact = _conditional_required_output_graph(
+        consumer_condition=AnyCondition(conditions=(present,))
+    )
+    PipelineCompiler(registry).compile(any_exact)
+
+
+@pytest.mark.asyncio
+async def test_optional_registered_output_requires_and_honors_presence_guard() -> None:
     async def maybe(_: StageContext, __: BaseModel) -> StageResult:
         return StageResult(status=StageExecutionStatus.COMPLETE)
 
@@ -577,6 +806,139 @@ async def test_conditional_output_requires_and_honors_typed_presence_guard() -> 
     )
     assert execution.result_for("maybe").status is StageExecutionStatus.COMPLETE
     assert execution.result_for("consume").status is StageExecutionStatus.SKIPPED
+
+
+@pytest.mark.asyncio
+async def test_failure_observer_receives_typed_context_and_original_error() -> None:
+    class UnexpectedStageError(RuntimeError):
+        pass
+
+    calls: list[str] = []
+    error = UnexpectedStageError("unexpected plugin failure")
+
+    async def fail(_: StageContext, __: BaseModel) -> StageResult:
+        calls.append("fail")
+        raise error
+
+    async def downstream(_: StageContext, __: BaseModel) -> StageResult:
+        calls.append("downstream")
+        return StageResult(
+            status=StageExecutionStatus.COMPLETE,
+            outputs={"text": "unreachable"},
+        )
+
+    registry = ComponentRegistry()
+    registry.register(
+        _registration(
+            "fail",
+            input_ports={"text": TEXT},
+            output_ports={"text": TEXT},
+            handler=fail,
+        )
+    )
+    registry.register(
+        _registration(
+            "downstream",
+            input_ports={"text": TEXT},
+            output_ports={"text": TEXT},
+            handler=downstream,
+        )
+    )
+    pipeline = PipelineCompiler(registry).compile(
+        _pipeline(
+            components=(
+                ComponentInstanceSpec(instance_id="fail", component_id="fail"),
+                ComponentInstanceSpec(
+                    instance_id="downstream",
+                    component_id="downstream",
+                ),
+            ),
+            stages=(
+                StageSpec(
+                    stage_id="fail",
+                    component="fail",
+                    inputs={"text": PipelineInputRef(input_name="text")},
+                    outputs=("text",),
+                ),
+                StageSpec(
+                    stage_id="downstream",
+                    component="downstream",
+                    depends_on=("fail",),
+                    inputs={
+                        "text": StageOutputRef(
+                            stage_id="fail",
+                            output_name="text",
+                        )
+                    },
+                    outputs=("text",),
+                ),
+            ),
+        )
+    )
+    observer = _RecordingFailureObserver()
+
+    with pytest.raises(UnexpectedStageError) as raised:
+        await PipelineOrchestrator(failure_observer=observer).execute(
+            pipeline,
+            {"text": "input"},
+            pipeline_run_id="pipeline-run-failure",
+            input_identity={"document": "artifact-123"},
+        )
+
+    assert raised.value is error
+    assert calls == ["fail"]
+    assert len(observer.failures) == 1
+    failure = observer.failures[0]
+    assert failure.pipeline_id == "test-pipeline"
+    assert failure.pipeline_version == "1"
+    assert failure.pipeline_run_id == "pipeline-run-failure"
+    assert failure.stage_id == "fail"
+    assert failure.component.component_id == "fail"
+    assert failure.configuration == {}
+    assert failure.configuration_sha256 == configuration_sha256({})
+    assert failure.input_identity == {"document": "artifact-123"}
+    assert failure.exception is error
+
+
+@pytest.mark.asyncio
+async def test_cancellation_bypasses_failure_observer() -> None:
+    async def cancel(_: StageContext, __: BaseModel) -> StageResult:
+        raise asyncio.CancelledError
+
+    registry = ComponentRegistry()
+    registry.register(
+        _registration(
+            "cancel",
+            input_ports={"text": TEXT},
+            output_ports={"text": TEXT},
+            handler=cancel,
+        )
+    )
+    pipeline = PipelineCompiler(registry).compile(
+        _pipeline(
+            components=(
+                ComponentInstanceSpec(instance_id="cancel", component_id="cancel"),
+            ),
+            stages=(
+                StageSpec(
+                    stage_id="cancel",
+                    component="cancel",
+                    inputs={"text": PipelineInputRef(input_name="text")},
+                    outputs=("text",),
+                ),
+            ),
+        )
+    )
+    observer = _RecordingFailureObserver()
+
+    with pytest.raises(asyncio.CancelledError):
+        await PipelineOrchestrator(failure_observer=observer).execute(
+            pipeline,
+            {"text": "input"},
+            input_identity={"document": "artifact-123"},
+        )
+
+    assert observer.failures == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_document_processing/test_pipeline.py
+++ b/tests/test_document_processing/test_pipeline.py
@@ -528,6 +528,22 @@ class _RecordingExecutor:
         return await self.local.execute(stage, context)
 
 
+class _RaiseAfterStageExecutor:
+    def __init__(self, stage_id: str) -> None:
+        self.stage_id = stage_id
+        self.local = LocalStageExecutor()
+
+    async def execute(
+        self,
+        stage: CompiledStage,
+        context: StageContext,
+    ) -> StageResult:
+        result = await self.local.execute(stage, context)
+        if stage.spec.stage_id == self.stage_id:
+            raise RuntimeError(f"unexpected failure after {self.stage_id}")
+        return result
+
+
 @pytest.mark.asyncio
 async def test_reference_flow_executes_through_the_compiled_local_dag(tmp_path) -> None:
     executor = _RecordingExecutor()
@@ -574,6 +590,80 @@ async def test_reference_flow_executes_through_the_compiled_local_dag(tmp_path) 
         "document-result",
     )
     assert not hasattr(processor, "_process_artifact_once_legacy")
+
+
+@pytest.mark.asyncio
+async def test_unexpected_stage_failure_persists_one_failed_run(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = ContentAddressedStore(tmp_path / "store")
+    docling = FakeDocling()
+    processor = DocumentProcessor(
+        store,
+        docling=docling,
+        grobid=FakeGrobid(),
+        ocrmypdf=FakeOCR(),
+        config=_config(),
+    )
+    artifact = processor.ingest_bytes(
+        b"<html><body>unexpected route failure</body></html>",
+        acquisition_uri="https://example.test/unexpected.html",
+        media_type="text/html",
+        identifiers={"filename": "unexpected.html"},
+    )
+
+    def unexpected_route(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("unexpected route failure")
+
+    monkeypatch.setattr(processor.router, "route", unexpected_route)
+
+    with pytest.raises(RuntimeError, match="unexpected route failure"):
+        await processor.process_artifact(artifact.artifact_id)
+
+    runs = store.list_processing_runs(artifact_id=artifact.artifact_id)
+    assert len(runs) == 1
+    failed = runs[0]
+    assert failed.status is ProcessingRunStatus.FAILED
+    assert failed.stage_id == "route"
+    assert (
+        failed.component
+        == processor.component_registry.require("document-router").descriptor
+    )
+    assert failed.configuration == {}
+    assert failed.configuration_sha256 == sha256_bytes(b"{}")
+    assert failed.pipeline_run_id is not None
+    assert failed.output("diagnostics_manifest") is not None
+    assert docling.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_failure_observer_does_not_duplicate_a_terminal_component_run(
+    tmp_path,
+) -> None:
+    store = ContentAddressedStore(tmp_path / "store")
+    processor = DocumentProcessor(
+        store,
+        docling=FakeDocling(),
+        grobid=FakeGrobid(),
+        ocrmypdf=FakeOCR(),
+        config=_config(),
+        stage_executor=_RaiseAfterStageExecutor("docling"),
+    )
+    artifact = processor.ingest_bytes(
+        b"<html><body>persist then fail</body></html>",
+        acquisition_uri="https://example.test/persisted.html",
+        media_type="text/html",
+        identifiers={"filename": "persisted.html"},
+    )
+
+    with pytest.raises(RuntimeError, match="unexpected failure after docling"):
+        await processor.process_artifact(artifact.artifact_id)
+
+    runs = store.list_processing_runs(artifact_id=artifact.artifact_id)
+    assert len(runs) == 1
+    assert runs[0].component_id == "docling"
+    assert runs[0].status is ProcessingRunStatus.COMPLETE
 
 
 @pytest.mark.asyncio

--- a/tests/test_document_processing/test_pipeline.py
+++ b/tests/test_document_processing/test_pipeline.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 import json
+import time
 from io import BytesIO
 from typing import Any
 
@@ -664,6 +665,57 @@ async def test_failure_observer_does_not_duplicate_a_terminal_component_run(
     assert len(runs) == 1
     assert runs[0].component_id == "docling"
     assert runs[0].status is ProcessingRunStatus.COMPLETE
+
+
+@pytest.mark.asyncio
+async def test_unrelated_terminal_run_does_not_hide_stage_failure(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = ContentAddressedStore(tmp_path / "store")
+    processor = DocumentProcessor(
+        store,
+        docling=FakeDocling(),
+        grobid=FakeGrobid(),
+        ocrmypdf=FakeOCR(),
+        config=_config(),
+    )
+    artifact = processor.ingest_bytes(
+        b"<html><body>unrelated run then route failure</body></html>",
+        acquisition_uri="https://example.test/unrelated-run.html",
+        media_type="text/html",
+        identifiers={"filename": "unrelated-run.html"},
+    )
+
+    def persist_unrelated_then_fail(*args: Any, **kwargs: Any) -> None:
+        unrelated_error = RuntimeError("unrelated terminal failure")
+        processor._save_failed_run(
+            artifact,
+            component_id="unrelated-component",
+            component_version="1",
+            stage_id="unrelated-stage",
+            configuration={},
+            started_at=utc_now(),
+            started_clock=time.perf_counter(),
+            error=unrelated_error,
+        )
+        raise RuntimeError("unexpected route failure")
+
+    monkeypatch.setattr(processor.router, "route", persist_unrelated_then_fail)
+
+    with pytest.raises(RuntimeError, match="unexpected route failure"):
+        await processor.process_artifact(artifact.artifact_id)
+
+    runs = store.list_processing_runs(artifact_id=artifact.artifact_id)
+    assert len(runs) == 2
+    by_stage = {run.stage_id: run for run in runs}
+    assert by_stage["unrelated-stage"].component_id == "unrelated-component"
+    assert by_stage["unrelated-stage"].status is ProcessingRunStatus.FAILED
+    assert by_stage["route"].component_id == "document-router"
+    assert by_stage["route"].status is ProcessingRunStatus.FAILED
+    assert (
+        by_stage["route"].pipeline_run_id == by_stage["unrelated-stage"].pipeline_run_id
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- treat outputs from conditional producers as potentially absent during compilation
- require exact typed `output_present` proofs for required downstream inputs
- persist unexpected component failures through a storage-independent observer contract
- prevent duplicate failed runs while preserving cancellation and the original exception
- validate the compiled pipeline against isolated Docling, GROBID, and OCRmyPDF boundaries
- run the exact pull-request head through tests, lint, formatting, types, lockfile, whitespace, docs, and live contracts

## Scope

This is the Phase 0 hardening follow-up to merged PR #252. It contains no canonical-view or scientific-extraction changes.

This upstream pull request supersedes EmployeeNo427/DeepCritical#6.

## Final validation

Exact head: `a266fb3be956ecb00d0ddde23d34b4584bdab25a`

- [Standard CI run 30994019726](https://github.com/DeepCritical/DeepCritical/actions/runs/30994019726): lint, formatting, types, and tests passed.
- [Exact-SHA quality and live run 30994019886](https://github.com/DeepCritical/DeepCritical/actions/runs/30994019886): all four jobs passed.
- Repository CI marker selection: 1,433 passed, 11 skipped, 515 deselected.
- Dedicated bioinformatics lane: 381 passed, 52 skipped, 43 deselected.
- Ruff lint and formatting passed; 527 files were correctly formatted.
- Full `ty check DeepResearch`, lockfile, whitespace, and documentation build passed.
- Isolated Docling, GROBID, and OCRmyPDF jobs each passed their direct client contract and compiled-pipeline smoke.

No required test marker was weakened, and no required job uses `continue-on-error`.